### PR TITLE
Delete PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-Fixes # <issue>
-
-## Proposed Changes
-
-  -
-  -
-  -


### PR DESCRIPTION
I find that the commit message description is usually more useful to have as autofill than a generic template
