### PR TITLE
Handle legacy explorer urls

### DIFF
--- a/components/nav-bar.js
+++ b/components/nav-bar.js
@@ -27,7 +27,7 @@ const StyledNavItem = styled.a`
   text-decoration: none;
   position: relative;
   display: inline;
-  padding-left: 16px;
+  margin-left: 16px;
 `
 
 const NavItemLabel = styled.span`
@@ -45,12 +45,12 @@ const Underline = styled.span`
   height: 2px;
   background: ${props => props.theme.colors.white};
   position: absolute;
-  left: 16px;
+  left: 0;
   bottom: -6px;
 
-  width: ${props => props.active ? 'calc(100% - 15px)' : '0px'};
+  width: ${props => props.active ? '100%' : '0px'};
   ${StyledNavItem}:hover & {
-    width: calc(100% - 15px);
+    width: calc(100%);
   }
 `
 

--- a/components/search/results-list.js
+++ b/components/search/results-list.js
@@ -91,9 +91,9 @@ const StyledViewDetailsLink = styled(Link)`
 `
 
 const ViewDetailsLink = ({reportId, input, children}) => {
-  let href = `/measurement?report_id=${reportId}`
+  let href = `/measurement/${reportId}`
   if (input) {
-    href += `&input=${input}`
+    href += `?input=${input}`
   }
   return (
     <NLink href={href}>

--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ app.prepare()
     })
 
     server.get('/measurement/:report_id', (req, res) => {
-      return app.render(req, res, '/measurement', req.params)
+      const combinedQuery = {...req.params, ...req.query}
+      return app.render(req, res, '/measurement', combinedQuery)
     })
 
     // Default catch all


### PR DESCRIPTION
This fixes problems with handling the URLs schema used by the old explorer e.g `https://explorer.ooni.torproject.org/measurement/report-id?input=website-url-tested`

The query string was being omitted when handing off the request to the new URL format. It is not captured and sent to the request handler.