### PR TITLE
Get the URL charts to look decent

### DIFF
--- a/components/colors.js
+++ b/components/colors.js
@@ -1,0 +1,6 @@
+import { theme } from 'ooni-components'
+
+export const colorNormal = theme.colors.green7
+export const colorError = theme.colors.yellow5
+export const colorConfirmed = theme.colors.red8
+export const colorAnomaly = theme.colors.yellow8

--- a/components/country/overview-charts.js
+++ b/components/country/overview-charts.js
@@ -8,7 +8,7 @@ import {
   VictoryAxis,
   VictoryTheme,
   VictoryLine,
-  VictoryVoronoiContainer,
+  VictoryVoronoiContainer
 } from 'victory'
 
 import Tooltip from './tooltip'
@@ -72,16 +72,28 @@ class TestsByGroup extends React.PureComponent {
   }
 
   render() {
+    let testCoverageMaxima, networkCoverageMaxima
+
     const { testCoverage, networkCoverage } = this.props
     const supportedTestGroups = ['websites', 'im', 'middlebox', 'performance', 'circumvention']
     const testCoverageByDay = testCoverage.reduce((prev, cur) => {
       prev[cur.test_day] = prev[cur.test_day] || {}
       prev[cur.test_day][cur.test_group] = cur.count
+      if (typeof testCoverageMaxima === 'undefined'
+          || testCoverageMaxima < cur.count) {
+        testCoverageMaxima = cur.count
+      }
       return prev
     }, {})
     const testCoverageArray = Object.keys(testCoverageByDay)
       .map(day => ({test_day: day, ...testCoverageByDay[day]}))
 
+    networkCoverage.forEach((d) => {
+      if (typeof networkCoverageMaxima === 'undefined'
+          || networkCoverageMaxima < d.count) {
+        networkCoverageMaxima = d.count
+      }
+    })
     const selectedTestGroups = Object.keys(this.state).filter(testGroup => this.state[testGroup])
     return (
       <React.Fragment>
@@ -98,87 +110,81 @@ class TestsByGroup extends React.PureComponent {
           }
         </Flex>
         {/* Bar chart */}
-        <Box>
-          <VictoryChart
-            domainPadding={20}
-            theme={VictoryTheme.material}
-            scale={{ x: 'time' }}
-            containerComponent={
-              <VictoryVoronoiContainer
-                responsive={false}
-                voronoiDimension='x'
-              />
-            }
-            width={800}
-          >
-            <VictoryAxis
-              dependentAxis
+        <VictoryChart
+          domainPadding={20}
+          theme={VictoryTheme.material}
+          containerComponent={
+            <VictoryVoronoiContainer
+              responsive={false}
+              voronoiDimension='x'
             />
-            <VictoryStack>
-              {
-                selectedTestGroups.map((testGroup, index) => {
-                  let maybeLabels = {}
-                  if (index === 0) {
-                    maybeLabels['labels'] = (d) => {
-                      let s = new Date(d.test_day).toLocaleDateString()
-                      selectedTestGroups.forEach((name) => {
-                        s += `\n${d[name]} ${name}`
-                      })
-                      return s
-                    }
-                    maybeLabels['labelComponent'] = <Tooltip />
+          }
+          domain={{ y: [0, 1] }}
+          width={800}
+          height={600}
+        >
+
+          <VictoryAxis tickCount={4} />
+          <VictoryAxis
+            dependentAxis
+            standalone={false}
+            tickFormat={(t) => t * testCoverageMaxima}
+          />
+          <VictoryStack standalone={false}>
+            {
+              selectedTestGroups.map((testGroup, index) => {
+                let maybeLabels = {}
+                if (index === 0) {
+                  maybeLabels['labels'] = (d) => {
+                    let s = new Date(d.test_day).toLocaleDateString()
+                    selectedTestGroups.forEach((name) => {
+                      s += `\n${d[name]} ${name}`
+                    })
+                    return s
                   }
-                  return (
-                    <VictoryBar
-                      {...maybeLabels}
-                      key={index}
-                      data={testCoverageArray}
-                      style={{
-                        data: {
-                          stroke: '#ffffff',
-                          strokeWidth: 1,
-                          fill: testGroups[testGroup].color
-                        }
-                      }}
-                      x='test_day'
-                      y={(d) => d[testGroup]}
-                    />
-                  )
-                })
-              }
-            </VictoryStack>
-          </VictoryChart>
-        </Box>
-        <Box>
-          <VictoryChart
-            scale={{ x: 'time' }}
-            height={120}
-            width={800}
-            containerComponent={
-              <VictoryVoronoiContainer
-                responsive={false}
-              />
-            }
-          >
-            <VictoryLine
-              data={networkCoverage}
-              x='test_day'
-              y='count'
-              labels={(d) => `${new Date(d.test_day).toLocaleDateString()}\n${d.count} networks`}
-              labelComponent={<Tooltip />}
-              style={{
-                data: {
-                  stroke: theme.colors.blue5,
+                  maybeLabels['labelComponent'] = <Tooltip />
                 }
-              }}
-            />
-            <VictoryAxis
-              dependentAxis
-              style={{ axis: { stroke: 'none'}}}
-              tickFormat={() => (null)}
-            />
-          </VictoryChart>
-        </Box>
+                return (
+                  <VictoryBar
+                    {...maybeLabels}
+                    key={index}
+                    data={testCoverageArray}
+                    standalone={false}
+                    style={{
+                      data: {
+                        stroke: '#ffffff',
+                        strokeWidth: 1,
+                        fill: testGroups[testGroup].color
+                      }
+                    }}
+                    x='test_day'
+                    y={(d) => d[testGroup] / testCoverageMaxima}
+                  />
+                )
+              })
+            }
+          </VictoryStack>
+          <VictoryAxis
+            dependentAxis
+            orientation="right"
+            standalone={false}
+            tickFormat={(t) => t * networkCoverageMaxima}
+          />
+          <VictoryLine
+            data={networkCoverage}
+            x='test_day'
+            y={(d) => d.count / networkCoverageMaxima}
+            scale={{x: 'time', y: 'linear'}}
+            labels={(d) => `${new Date(d.test_day).toLocaleDateString()}\n${d.count} networks `}
+            labelComponent={<Tooltip />}
+            standalone={false}
+            style={{
+              data: {
+                stroke: theme.colors.gray7,
+              }
+            }}
+          />
+        </VictoryChart>
       </React.Fragment>
     )
   }

--- a/components/country/tooltip.js
+++ b/components/country/tooltip.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import {
+  VictoryTooltip,
+  VictoryLabel
+} from 'victory'
+
+import { theme } from 'ooni-components'
+
+const Tooltip = (props) => (<VictoryTooltip
+  {...props}
+  labelComponent={
+    <VictoryLabel style={{fill: theme.colors.white}}/>
+  }
+  flyoutStyle={{
+    strokeWidth: 0,
+    fill: theme.colors.gray8,
+    padding: 2,
+    pointerEvents: 'none'
+  }}
+/>)
+
+export default Tooltip

--- a/components/country/url-chart.js
+++ b/components/country/url-chart.js
@@ -7,7 +7,9 @@ import {
   VictoryStack,
   VictoryBar,
   VictoryAxis,
-  VictoryVoronoiContainer
+  VictoryVoronoiContainer,
+  VictoryTooltip,
+  VictoryLabel
 } from 'victory'
 import { theme } from 'ooni-components'
 import styled from 'styled-components'
@@ -100,9 +102,9 @@ class URLChart extends React.Component {
     const { data, minimized, fetching } = this.state
     const dataColorMap = {
       total_count: theme.colors.gray3,
-      confirmed_count: theme.colors.green8,
+      confirmed_count: theme.colors.red8,
       anomaly_count: theme.colors.yellow9,
-      failure_count: theme.colors.red8
+      failure_count: theme.colors.gray7
     }
 
     if (fetching) {
@@ -129,17 +131,11 @@ class URLChart extends React.Component {
                 <VictoryChart
                   // theme={VictoryTheme.material}
                   scale={{x: 'time'}}
-                  height={minimized ? 150 : 400}
+                  height={150}
                   containerComponent={
                     <VictoryVoronoiContainer
                       responsive={false}
-                      labels={(d) => `
-                    Total: ${d.total_count} \n
-                    Confirmed: ${d.confirmed_count} \n
-                    Anomalies: ${d.anomaly_count} \n
-                    Failures: ${d.failure_count} \n
-                    Date: ${new Date(d.test_day).toLocaleDateString()}
-                  `}
+                      voronoiDimension='x'
                     />
                   }
                 >
@@ -148,6 +144,36 @@ class URLChart extends React.Component {
                     tickFormat={() => {}}
                   />
                   <VictoryStack>
+                    <VictoryBar
+                      labels={(d) => `${new Date(d.test_day).toLocaleDateString()}
+                        Total: ${d.total_count}
+                        Confirmed: ${d.confirmed_count}
+                        Anomalies: ${d.anomaly_count}
+                        Failures: ${d.failure_count}
+                      `}
+                      labelComponent={
+                        <VictoryTooltip
+                          width={100}
+                          labelComponent={
+                            <VictoryLabel style={{fill: theme.colors.white}}/>
+                          }
+                          flyoutStyle={{
+                            strokeWidth: 0,
+                            fill: theme.colors.gray8,
+                            padding: 2,
+                            pointerEvents: 'none'
+                          }}
+                        />
+                      }
+                      data={data}
+                      x='test_day'
+                      y={(d) => (d.total_count - d.confirmed_count - d.anomaly_count - d.failure_count)}
+                      style={{
+                        data: {
+                          fill: dataColorMap.total_count,
+                        }
+                      }}
+                    />
                     {
                       ['confirmed_count', 'anomaly_count', 'failure_count'].map((type, index) => (
                         <VictoryBar
@@ -164,16 +190,6 @@ class URLChart extends React.Component {
                         />
                       ))
                     }
-                    <VictoryBar
-                      data={data}
-                      x='test_day'
-                      y={(d) => (d.total_count - d.confirmed_count - d.anomaly_count - d.failure_count)}
-                      style={{
-                        data: {
-                          fill: dataColorMap.total_count,
-                        }
-                      }}
-                    />
                   </VictoryStack>
                 </VictoryChart>
               }

--- a/components/country/url-chart.js
+++ b/components/country/url-chart.js
@@ -14,6 +14,13 @@ import {
 import { theme } from 'ooni-components'
 import styled from 'styled-components'
 
+import {
+  colorNormal,
+  colorError,
+  colorConfirmed,
+  colorAnomaly
+} from '../colors'
+
 import SpinLoader from '../vendor/spin-loader'
 
 const Circle = styled.div`
@@ -101,10 +108,10 @@ class URLChart extends React.Component {
     const { metadata } = this.props
     const { data, minimized, fetching } = this.state
     const dataColorMap = {
-      total_count: theme.colors.gray3,
-      confirmed_count: theme.colors.red8,
-      anomaly_count: theme.colors.yellow9,
-      failure_count: theme.colors.gray7
+      total_count: colorNormal,
+      confirmed_count: colorConfirmed,
+      anomaly_count: colorAnomaly,
+      failure_count: colorError
     }
 
     if (fetching) {
@@ -145,12 +152,20 @@ class URLChart extends React.Component {
                   />
                   <VictoryStack>
                     <VictoryBar
-                      labels={(d) => `${new Date(d.test_day).toLocaleDateString()}
-                        Total: ${d.total_count}
-                        Confirmed: ${d.confirmed_count}
-                        Anomalies: ${d.anomaly_count}
-                        Failures: ${d.failure_count}
-                      `}
+                      labels={(d) => {
+                        let s = `${new Date(d.test_day).toLocaleDateString()}`
+                        if (d.confirmed_count > 0) {
+                          s += `\n${d.confirmed_count} Confirmed`
+                        }
+                        if (d.anomaly_count > 0) {
+                          s += `\n${d.anomaly_count} Anomalies`
+                        }
+                        if (d.failure_count > 0) {
+                          s += `\n${d.failure_count} Failures`
+                        }
+                        s += `\n${d.total_count} Total`
+                        return s
+                      }}
                       labelComponent={
                         <VictoryTooltip
                           width={100}

--- a/components/country/url-chart.js
+++ b/components/country/url-chart.js
@@ -7,10 +7,9 @@ import {
   VictoryStack,
   VictoryBar,
   VictoryAxis,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
-  VictoryLabel
+  VictoryVoronoiContainer
 } from 'victory'
+
 import { theme } from 'ooni-components'
 import styled from 'styled-components'
 
@@ -20,6 +19,8 @@ import {
   colorConfirmed,
   colorAnomaly
 } from '../colors'
+
+import Tooltip from './tooltip'
 
 import SpinLoader from '../vendor/spin-loader'
 
@@ -166,20 +167,7 @@ class URLChart extends React.Component {
                         s += `\n${d.total_count} Total`
                         return s
                       }}
-                      labelComponent={
-                        <VictoryTooltip
-                          width={100}
-                          labelComponent={
-                            <VictoryLabel style={{fill: theme.colors.white}}/>
-                          }
-                          flyoutStyle={{
-                            strokeWidth: 0,
-                            fill: theme.colors.gray8,
-                            padding: 2,
-                            pointerEvents: 'none'
-                          }}
-                        />
-                      }
+                      labelComponent={<Tooltip width={100} />}
                       data={data}
                       x='test_day'
                       y={(d) => (d.total_count - d.confirmed_count - d.anomaly_count - d.failure_count)}

--- a/components/search/results-list.js
+++ b/components/search/results-list.js
@@ -11,9 +11,15 @@ import {
   Flex, Box,
   Link,
   Text,
-  Divider,
-  theme
+  Divider
 } from 'ooni-components'
+
+import {
+  colorNormal,
+  colorError,
+  colorConfirmed,
+  colorAnomaly
+} from '../colors'
 
 import Flag from '../flag'
 
@@ -112,11 +118,6 @@ const StyledColorCode = styled.div`
   width: 5px;
   margin-right: 10px;
 `
-
-const colorNormal = theme.colors.green7
-const colorError = theme.colors.yellow5
-const colorConfirmed = theme.colors.red8
-const colorAnomaly = theme.colors.yellow8
 
 const ColorCodeConfirmed = styled(StyledColorCode)`
   background-color: ${colorConfirmed};


### PR DESCRIPTION
Implements tooltips as per the discussion in #84.

I also cleaned up a bit the chart in the overview section, but I could not figure out a way to make the two charts be linked (i.e. so that when you scrub over any of the two graphs the tooltip appears on both of them).