### PR TITLE
Parse markdown in translated strings

### DIFF
--- a/components/country/apps.js
+++ b/components/country/apps.js
@@ -6,6 +6,7 @@ import { SimpleBox } from './box'
 import PeriodFilter from './period-filter'
 import AppsStatsGroup from './apps-stats'
 import AppsStatsCircumvention from './apps-stats-circumvention'
+import FormattedMarkdown from '../formatted-markdown'
 
 const AppsSection = () => (
   <React.Fragment>
@@ -18,7 +19,7 @@ const AppsSection = () => (
       </Box> */}
     </SectionHeader>
     <SimpleBox>
-      <FormattedMessage id='Country.Apps.Description' />
+      <FormattedMarkdown id='Country.Apps.Description' />
     </SimpleBox>
     {/* App-wise graphs */}
     <AppsStatsGroup

--- a/components/country/overview.js
+++ b/components/country/overview.js
@@ -5,6 +5,7 @@ import { Flex, Box, Heading } from 'ooni-components'
 import SectionHeader from './section-header'
 import { BoxWithTitle } from './box'
 import TestsByGroup from './overview-charts'
+import FormattedMarkdown from '../formatted-markdown'
 import {
   NettestGroupWebsites,
   NettestGroupInstantMessaging,
@@ -126,7 +127,7 @@ const Overview = ({
       {/* Highlight Box */}
       {/* <SummaryText> */}
       <SummaryText>
-        <FormattedMessage
+        <FormattedMarkdown
           id='Country.Overview.SummaryTextTemplate'
           values={{
             measurementCount,

--- a/components/country/websites.js
+++ b/components/country/websites.js
@@ -9,6 +9,7 @@ import { SimpleBox } from './box'
 import PeriodFilter from './period-filter'
 import ASNSelector from './asn-selector'
 import TestsByCategoryInNetwork from './websites-charts'
+import FormattedMarkdown from '../formatted-markdown'
 
 class WebsitesSection extends React.Component {
   constructor(props) {
@@ -55,7 +56,7 @@ class WebsitesSection extends React.Component {
         </Box> */}
         <SimpleBox>
           <Text>
-            <FormattedMessage id='Country.Websites.Description' />
+            <FormattedMarkdown id='Country.Websites.Description' />
           </Text>
         </SimpleBox>
 

--- a/components/formatted-markdown.js
+++ b/components/formatted-markdown.js
@@ -1,0 +1,19 @@
+//
+import React from 'react'
+import PropTypes from 'prop-types'
+import { injectIntl, intlShape } from 'react-intl'
+import Markdown from 'markdown-to-jsx'
+
+const FormattedMarkdown = ({ intl, id }) => (
+  // <Markdown source={intl.formatMessage({ id })} />
+  <Markdown>
+    {intl.formatMessage({ id })}
+  </Markdown>
+)
+
+FormattedMarkdown.propTypes = {
+  intl: intlShape,
+  id: PropTypes.string.isRequired
+}
+
+export default injectIntl(FormattedMarkdown)

--- a/components/formatted-markdown.js
+++ b/components/formatted-markdown.js
@@ -1,4 +1,5 @@
-//
+// Documentation for markdown-to-jsx
+// https://github.com/probablyup/markdown-to-jsx
 import React from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'

--- a/components/formatted-markdown.js
+++ b/components/formatted-markdown.js
@@ -6,7 +6,6 @@ import { injectIntl, intlShape } from 'react-intl'
 import Markdown from 'markdown-to-jsx'
 
 const FormattedMarkdown = ({ intl, id }) => (
-  // <Markdown source={intl.formatMessage({ id })} />
   <Markdown>
     {intl.formatMessage({ id })}
   </Markdown>

--- a/components/formatted-markdown.js
+++ b/components/formatted-markdown.js
@@ -5,15 +5,16 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import Markdown from 'markdown-to-jsx'
 
-const FormattedMarkdown = ({ intl, id }) => (
+const FormattedMarkdown = ({ intl, id, values }) => (
   <Markdown>
-    {intl.formatMessage({ id })}
+    {intl.formatMessage({ id }, values)}
   </Markdown>
 )
 
 FormattedMarkdown.propTypes = {
   intl: intlShape,
-  id: PropTypes.string.isRequired
+  id: PropTypes.string.isRequired,
+  values: PropTypes.object
 }
 
 export default injectIntl(FormattedMarkdown)

--- a/components/measurement/SummaryText.js
+++ b/components/measurement/SummaryText.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import { Text } from 'ooni-components'
-import { FormattedMessage } from 'react-intl'
 
 import { getTestMetadata } from '../utils'
+import FormattedMarkdown from '../formatted-markdown'
 
 const SummaryText = ({
   testName,
@@ -12,8 +12,7 @@ const SummaryText = ({
   country,
   date,
   content,
-  testUrl,
-
+  testUrl
 }) => {
   const metadata = getTestMetadata(testName)
   const formattedDate = moment(date).format('LL')
@@ -24,8 +23,7 @@ const SummaryText = ({
     textToRender = content()
   } else {
     textToRender =
-      <FormattedMessage id='Measurement.Details.SummaryTextTemplate'
-        description='This is a multi-sentence paragraph with tokens.'
+      <FormattedMarkdown id='Measurement.Details.SummaryTextTemplate'
         values={{
           testName: <a href={metadata.info}>{metadata.name}</a>,
           network: network,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "immutable": "^3.8.1",
     "lodash.debounce": "^4.0.8",
     "lodash.random": "^3.2.0",
+    "markdown-to-jsx": "^6.9.4",
     "moment": "^2.20.1",
     "next": "6.0.3",
     "nprogress": "^0.2.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import Head from 'next/head'
 import NLink from 'next/link'
-
+import FormattedMarkdown from '../components/formatted-markdown'
 import styled from 'styled-components'
 import axios from 'axios'
 import { FormattedMessage } from 'react-intl'
@@ -146,7 +146,7 @@ export default class LandingPage extends React.Component {
           <Flex justifyContent='center'>
             <Box width={[1, 2/3]}>
               <Text fontSize={20} lineHeight={1.5}>
-                <FormattedMessage id='Home.About.SummaryText' />
+                <FormattedMarkdown id='Home.About.SummaryText' />
               </Text>
             </Box>
           </Flex>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4387,6 +4387,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-to-jsx@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.9.4.tgz#ed1e6925e643f7a0ee2fed90f28d16b4402aad09"
+  integrity sha512-Fvx2ZhiknGmcLsWVjIq6MmiN9gcCot8w+jzwN2mLXZcQsJGRN3Zes5Sp5M9YNIzUy/sDyuOTjimFdtAcvvmAPQ==
+  dependencies:
+    prop-types "^15.6.2"
+    unquote "^1.1.0"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -7113,6 +7121,11 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+unquote@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
+  integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- [x] Add component similar to `<FormattedMessage>` to fetch the translated string and render the markdown content in it

Use the above component to parse markdown in these places:
- [x] Home page intro text
- [x] ~Home Page - highlights~ (will be implemented as part of the highlights page PR)
- [x] Country page - overview
- [x] Country page - Websites description
- [x] Country page - Apps description
- [x] Measurement - Details - SummaryText