### PR TITLE
Remove repeated headers from HTTP responses

### DIFF
--- a/components/measurement/nettests/web_connectivity.js
+++ b/components/measurement/nettests/web_connectivity.js
@@ -130,10 +130,10 @@ const RequestResponseContainer = ({request}) => {
               <React.Fragment key={index}>
                 <Flex mb={2}>
                   <Box mr={1}>
-                    <Text fontWeight='bold'>{header}{header}{header}:</Text>
+                    <Text fontWeight='bold'>{header}:</Text>
                   </Box>
                   <Box>
-                    {request.response.headers[header]}{request.response.headers[header]}{request.response.headers[header]}
+                    {request.response.headers[header]}
                   </Box>
                 </Flex>
               </React.Fragment>


### PR DESCRIPTION
This was added to demonstrate how longer strings in header values are handled. Was committed accidentally.