### PR TITLE
Set bigger font size for subtext under measurement status label

### DIFF
--- a/components/measurement/Hero.js
+++ b/components/measurement/Hero.js
@@ -55,7 +55,9 @@ const Hero = ({ status, color, icon, label, info }) => {
           </Box>
         </Flex>
         {info && <Flex flexWrap='wrap' justifyContent='center'>
-          {info}
+          <Text fontSize={28}>
+            {info}
+          </Text>
         </Flex>}
       </Container>
     </HeroContainer>


### PR DESCRIPTION
Closes #168
Closes #119

![image](https://user-images.githubusercontent.com/700829/59037937-3cbfd480-8840-11e9-8506-c62fcebc25d3.png)
