### PR TITLE
Flag and country name in Measurement page

### DIFF
--- a/components/flag.js
+++ b/components/flag.js
@@ -32,13 +32,14 @@ const FlagImg = styled.img`
 
 const FlagContainer = styled.div`
   border-radius: 50%;
-  padding-left: 3px;
-  padding-top: 3px;
+  /* padding-left: 3px; */
+  /* padding-top: 3px; */
   width: ${props => props.size + 6}px;
   height: ${props => props.size + 6}px;
+  border: ${props => props.border ? '3px solid white' : 'none'};
 `
 
-export const Flag = ({countryCode, size}) => {
+export const Flag = ({countryCode, size, border}) => {
   countryCode = countryCode.toLowerCase()
   if (supportedCountryCodes.indexOf(countryCode) === -1) {
     // Map unsupported country codes to ZZ
@@ -46,7 +47,7 @@ export const Flag = ({countryCode, size}) => {
   }
   const src = `/static/flags/1x1/${countryCode}.svg`
   return (
-    <FlagContainer className='country-flag' size={size}>
+    <FlagContainer className='country-flag' size={size} border={border}>
       <FlagImg src={src} size={size} />
     </FlagContainer>
   )

--- a/components/measurement/CommonSummary.js
+++ b/components/measurement/CommonSummary.js
@@ -25,7 +25,7 @@ const SummaryItemBox = ({
   label,
   content
 }) => (
-  <Box width={[1, 1/2]} px={4} py={2}>
+  <Box width={[1, 1/3]} px={4} py={2}>
     <Text fontSize={24} fontWeight={300}>
       {content}
     </Text>
@@ -50,9 +50,9 @@ const CommonSummary = ({
   const network = measurement.probe_asn
   const countryCode = measurement.probe_cc
 
-  const countryBlock = <Flex alignItems='center' flexWrap='wrap'>
-    <Box mr={2} width={[1, 'unset']}>
-      <Flag countryCode={countryCode} size={22} border />
+  const countryBlock = <Flex flexWrap='wrap'>
+    <Box mr={2} pb={1} width={1}>
+      <Flag countryCode={countryCode} size={60} border />
     </Box>
     <Box>
       {country}
@@ -63,18 +63,18 @@ const CommonSummary = ({
     <React.Fragment>
       <SummaryContainer py={4} color={color}>
         <Container>
-          <Flex flexWrap='wrap'>
+          <Flex flexWrap='wrap' alignItems='flex-end' justifyContent='space-around'>
             {/*<SummaryItemBox
               label='Network Name'
               content='AT&T Lorem Ipsum Name A.T.T Internationale'
             />*/}
             <SummaryItemBox
-              label={intl.formatMessage({ id: 'Measurement.CommonSummary.Label.ASN' })}
-              content={network}
-            />
-            <SummaryItemBox
               label={intl.formatMessage({ id: 'Measurement.CommonSummary.Label.Country' })}
               content={countryBlock}
+            />
+            <SummaryItemBox
+              label={intl.formatMessage({ id: 'Measurement.CommonSummary.Label.ASN' })}
+              content={network}
             />
             <SummaryItemBox
               label={intl.formatMessage({ id: 'Measurement.CommonSummary.Label.DateTime' })}

--- a/components/measurement/CommonSummary.js
+++ b/components/measurement/CommonSummary.js
@@ -52,7 +52,7 @@ const CommonSummary = ({
 
   const countryBlock = <Flex alignItems='center'>
     <Box mr={2} >
-      <Flag countryCode={countryCode} size={22} />
+      <Flag countryCode={countryCode} size={22} border />
     </Box>
     <Box>
       {country}

--- a/components/measurement/CommonSummary.js
+++ b/components/measurement/CommonSummary.js
@@ -50,8 +50,8 @@ const CommonSummary = ({
   const network = measurement.probe_asn
   const countryCode = measurement.probe_cc
 
-  const countryBlock = <Flex alignItems='center'>
-    <Box mr={2} >
+  const countryBlock = <Flex alignItems='center' flexWrap='wrap'>
+    <Box mr={2} width={[1, 'unset']}>
       <Flag countryCode={countryCode} size={22} border />
     </Box>
     <Box>


### PR DESCRIPTION
Closes #116 

As per https://github.com/ooni/explorer/issues/116#issuecomment-499896501, we now have a white border around the flag.

![image](https://user-images.githubusercontent.com/700829/60687184-fe3b2b00-9e7a-11e9-9f4e-828fd7c60746.png)

Awaiting response from @hellais on above issue thread for another possible commit in this PR.