### PR TITLE
Fix layout of common details on measurement pages

### DIFF
--- a/components/measurement/CommonDetails.js
+++ b/components/measurement/CommonDetails.js
@@ -93,7 +93,7 @@ const CommonDetails = ({
         />
       </Flex>
       {/* Raw Measurement */}
-      <Box>
+      <Flex>
         <DetailsBox
           collapsed={true}
           title={
@@ -120,7 +120,7 @@ const CommonDetails = ({
             </Flex>
           }
         />
-      </Box>
+      </Flex>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Fix the layout mess in the common details at the bottom of measurement pages.
![image](https://user-images.githubusercontent.com/700829/62170486-876a4400-b2f9-11e9-902a-a673f1939564.png)
