### PR TITLE
Render error page when missing keys in DASH test

### DIFF
--- a/components/measurement/nettests/dash.js
+++ b/components/measurement/nettests/dash.js
@@ -93,6 +93,13 @@ const DashDetails = ({ measurement, render, intl }) => {
   const testKeys = measurement.test_keys
   // const isFailed = testKeys.failure !== null
   // const failure = testKeys.failure
+
+  if (typeof testKeys.simple === 'undefined' || typeof testKeys.receiver_data === 'undefined') {
+    return render({
+      status: 'error'
+    })
+  }
+
   const optimalVideoRate = getOptimalQualityForBitrate(testKeys).type
   const medianBitrate = (testKeys.simple.median_bitrate / 1000).toFixed(2)
   const playoutDelay = (testKeys.simple.min_playout_delay).toFixed(2)


### PR DESCRIPTION
Fixes crashing measurement pages like [this](http://explorer-beta.ooni.io/measurement/20190728T224449Z_AS327712_sJlefoZrC8Lhq9OUyVV40mOCzWJWQn0Iq5PHW9bQtJ3AUjvQWF)