### PR TITLE
Show anomaly or blocking reason in hero

### DIFF
--- a/components/measurement/Hero.js
+++ b/components/measurement/Hero.js
@@ -50,12 +50,12 @@ const Hero = ({ status, color, icon, label, info }) => {
     <HeroContainer py={4} color={color}>
       <Container>
         <Text fontWeight={600} fontSize={4} as='div'>
-          <Flex mb={4} justifyContent='center' alignItems='center'>
-            <Box mb={1}>{icon}</Box> <Box> {label} </Box>
+          <Flex my={2} justifyContent='center' alignItems='center'>
+            <Box>{icon}</Box> <Box>{label}</Box>
           </Flex>
         </Text>
         {info &&
-          <Text fontSize={28} textAlign='center'>
+          <Text fontSize={28} textAlign='center' as='div'>
             {info}
           </Text>
         }

--- a/components/measurement/nettests/web_connectivity.js
+++ b/components/measurement/nettests/web_connectivity.js
@@ -367,7 +367,7 @@ const WebConnectivityDetails = ({
     )
   } else if (isAnomaly) {
     status = 'anomaly'
-    reason = reasons[blocking]
+    reason = intl.formatMessage(messages[`blockingReason.${blocking}`])
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.Anomaly'
@@ -439,7 +439,7 @@ const WebConnectivityDetails = ({
     <React.Fragment>
       {render({
         status: status,
-        statusInfo: <StatusInfo url={input} />,
+        statusInfo: <StatusInfo url={input} message={reason || null} />,
         summaryText: summaryText,
         details: (
           <React.Fragment>

--- a/components/measurement/nettests/web_connectivity.js
+++ b/components/measurement/nettests/web_connectivity.js
@@ -49,50 +49,6 @@ const messages = defineMessages({
   },
 })
 
-export const checkAnomaly = ( testKeys ) => {
-  const {
-    accessible,
-    blocking,
-  } = testKeys
-
-  let anomaly = null
-  let hint = <FormattedMessage id='Measurement.Status.Hint.Websites.NoCensorship' />
-
-  if ((accessible === true || accessible === null) && blocking === null) {
-    hint = <FormattedMessage id='Measurement.Status.Hint.Websites.Error' />
-    if (accessible === true) {
-      anomaly = 'SITEUP'
-    } else if (accessible === null) {
-      anomaly = 'UNKNOWN'
-    }
-  } else if (accessible === false && (blocking === false || blocking === null)) {
-    anomaly = 'SITEDOWN'
-    hint = <FormattedMessage id='Measurement.Status.Hint.Websites.Unavailable' />
-  } else if (blocking !== null && blocking !== false) {
-    anomaly = 'CENSORSHIP'
-    hint = <FormattedMessage id='Measurement.Status.Hint.Websites.Censorship' />
-    // Further identify type of censorship
-    if (blocking === 'dns') {
-      anomaly = 'DNS'
-      hint = <FormattedMessage id='Measurement.Status.Hint.Websites.DNS' />
-    } else if (blocking === 'http-diff') {
-      anomaly = 'HTTPDIFF'
-      hint = <FormattedMessage id='Measurement.Status.Hint.Websites.HTTPdiff' />
-    } else if (blocking === 'http-failure') {
-      anomaly = 'HTTPFAILURE'
-      hint = <FormattedMessage id='Measurement.Status.Hint.Websites.HTTPfail' />
-    } else if (blocking === 'tcp-ip') {
-      anomaly = 'TCPIP'
-      hint = <FormattedMessage id='Measurement.Status.Hint.Websites.TCPBlock' />
-    }
-  }
-
-  return {
-    status: anomaly,
-    hint
-  }
-}
-
 const StatusInfo = ({ url, message}) => (
   <Flex flexDirection='column'>
     <Box mb={3}>

--- a/components/measurement/nettests/web_connectivity.js
+++ b/components/measurement/nettests/web_connectivity.js
@@ -95,7 +95,7 @@ export const checkAnomaly = ( testKeys ) => {
 
 const StatusInfo = ({ url, message}) => (
   <Flex flexDirection='column'>
-    <Box>
+    <Box mb={3}>
       <Text textAlign='center' fontSize={28}> {url} </Text>
     </Box>
     <Box>

--- a/components/measurement/nettests/web_connectivity.js
+++ b/components/measurement/nettests/web_connectivity.js
@@ -309,7 +309,7 @@ const WebConnectivityDetails = ({
   // } else
   if(isConfirmed) {
     status = 'confirmed'
-    reason = reasons[blocking]
+    reason = blocking && intl.formatMessage(messages[`blockingReason.${blocking}`])
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.ConfirmedBlocked'


### PR DESCRIPTION
Closes #179 
Now we show reason in Hero like so:
![image](https://user-images.githubusercontent.com/700829/62373896-c0c4ce80-b508-11e9-8aa5-81474107e576.png)

Works on confirmed blocked pages too:
![image](https://user-images.githubusercontent.com/700829/62373934-dafeac80-b508-11e9-9165-e2e849dde620.png)
 
I found an exception in this measurement. It is flagged with `isConfirmed = true` because it does serve a block page. But it shows up [normal on old explorer](https://explorer.ooni.io/measurement/20190703T163625Z_AS8708_UwLHVRiAoYGcScetNQ2uobFjyawbW11oqw4ZMIN8qJEZEF41pX?input=http:%2F%2Fwww.slotland.com). Because `test_keys.blocking = false`, it doesn't pick up from the map of reasons we use otherwise. Is there a way to determine reasons for such measurements? Just apply `blockingReason.http-diff` to all confirmed ones?

https://explorer-beta.ooni.io/measurement/20190703T163625Z_AS8708_UwLHVRiAoYGcScetNQ2uobFjyawbW11oqw4ZMIN8qJEZEF41pX?input=http://www.slotland.com