### PR TITLE
Fix for manual date entry

### DIFF
--- a/components/search/filter-sidebar.js
+++ b/components/search/filter-sidebar.js
@@ -162,10 +162,18 @@ class FilterSidebar extends React.Component {
 
   onDateChangeFilter (filterName) {
     return ((date) => {
-      this.setState({
-        [filterName]: (date !== '') ? date.utc().format('YYYY-MM-DD') : date,
-        isFilterDirty: true
-      })
+      if (moment(new Date(date)).isValid()) {
+        const newDate = moment.isMoment(date) ? date.format('YYYY-MM-DD') : date
+        this.setState({
+          [filterName]: newDate,
+          isFilterDirty: true
+        })
+      } else {
+        this.setState({
+          [filterName]: date,
+          isFilterDirty: false
+        })
+      }
     })
   }
 
@@ -253,7 +261,7 @@ class FilterSidebar extends React.Component {
             )
           })}
         </SelectWithLabel>
-        
+
         <InputWithLabel
           label={intl.formatMessage({id: 'Search.Sidebar.ASN'})}
           value={asnFilter}
@@ -271,6 +279,7 @@ class FilterSidebar extends React.Component {
             <DatePicker
               value={sinceFilter}
               onChange={this.onDateChangeFilter('sinceFilter')}
+              dateFormat='YYYY-MM-DD'
               timeFormat={false}
               isValidDate={this.isSinceValid}
             />
@@ -282,6 +291,7 @@ class FilterSidebar extends React.Component {
             <DatePicker
               value={untilFilter}
               onChange={this.onDateChangeFilter('untilFilter')}
+              dateFormat='YYYY-MM-DD'
               timeFormat={false}
               isValidDate={this.isUntilValid}
             />

--- a/components/search/filter-sidebar.js
+++ b/components/search/filter-sidebar.js
@@ -162,7 +162,7 @@ class FilterSidebar extends React.Component {
 
   onDateChangeFilter (filterName) {
     return ((date) => {
-      if (moment(new Date(date)).isValid()) {
+      if (moment(new Date(date)).isValid() || date === '') {
         const newDate = moment.isMoment(date) ? date.format('YYYY-MM-DD') : date
         this.setState({
           [filterName]: newDate,


### PR DESCRIPTION
Closes #321 

So far, this fixes the formatting bug when the input field is manually edited to any value. While it prevents arbitrary values from being inserted into the search query, it still accepts bizarre values like `1111` which are valid date formats (not ISO).