### PR TITLE
Use correct icon for Vanilla Tor in circumvention section

### DIFF
--- a/components/country/apps-stats-circumvention-row.js
+++ b/components/country/apps-stats-circumvention-row.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl'
 import { Flex, Box, Link, Text, theme } from 'ooni-components'
 import styled from 'styled-components'
 import {
-  NettestWhatsApp
+  NettestVanillaTor
 } from 'ooni-components/dist/icons'
 import moment from 'moment'
 
@@ -131,7 +131,7 @@ class AppsStatsCircumventionRow extends React.Component {
       <StyledRow p={3}>
         <Flex flexWrap='wrap' alignItems='center'>
           <Box mr={3}>
-            <NettestWhatsApp size={36} />
+            <NettestVanillaTor size={36} />
           </Box>
           <Box width={4/12}>
             Vanilla Tor

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "moment": "^2.20.1",
     "next": "8.1.0",
     "nprogress": "^0.2.0",
-    "ooni-components": "0.2.8",
+    "ooni-components": "0.2.9",
     "pretty-ms": "^3.2.0",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4537,10 +4537,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-ooni-components@0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/ooni-components/-/ooni-components-0.2.8.tgz#d302c248ca0dcbf5cb5b22c470f3eedc5fbd4cf0"
-  integrity sha512-iMdLNwmXrG2RgxHHaLhW0PY6pUIXeZwcRU+Mv1EvavLyicFqfk5kFLAiuLDa6lcPI/yOOLnfPZuMNOU+MaudQg==
+ooni-components@0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/ooni-components/-/ooni-components-0.2.9.tgz#0b09c443e6680aa7e2a7ac73afadb58d2585eb74"
+  integrity sha512-SKFnc6PtqUziPI8UZkGtJbJMZJUaMGKXVjZlp6fGshUW9o63LpHVlGS28ntWlBHsTPxkS9rts2EjsllPqRIFFA==
   dependencies:
     "@rebass/grid" "^6.0.0-3"
     palx "^1.0.2"


### PR DESCRIPTION
Upgrades `ooni-components` to use the right icon like in the screenshot.

![image](https://user-images.githubusercontent.com/700829/65825017-b04a7f00-e23f-11e9-9e61-67528da61cc4.png)
