### PR TITLE
Use corrected name for color fuschia

### DIFF
--- a/components/test-info.js
+++ b/components/test-info.js
@@ -31,7 +31,7 @@ export const testGroups = {
     'icon': <NettestGroupMiddleBoxes />
   },
   'performance': {
-    'color': theme.colors.fuschia6,
+    'color': theme.colors.fuchsia6,
     'name': <FormattedMessage id='Tests.Groups.Performance.Name' />,
     'icon': <NettestGroupPerformance />
   },


### PR DESCRIPTION
Change color name from `fuschia` to `fuchsia`

Fixes #18 