### PR TITLE
Add links to RSS feeds from Fastpath event detector

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -13,6 +13,7 @@ export default class Header extends React.Component {
           <meta charSet='utf-8'/>
           <meta name='viewport' content='initial-scale=1.0, width=device-width'/>
           <meta name='description' content={description} />
+          <link rel="alternate" title="Events Detected by OONI" href="http://fastpath.ooni.nu:8080/rss/global.xml" type="application/rss+xml" />
           <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicons/apple-icon-180x180.png" />
           <link rel="icon" type="image/png" sizes="192x192"  href="/static/images/favicons/android-icon-192x192.png" />
           <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicons/favicon-32x32.png" />

--- a/components/header.js
+++ b/components/header.js
@@ -13,7 +13,7 @@ export default class Header extends React.Component {
           <meta charSet='utf-8'/>
           <meta name='viewport' content='initial-scale=1.0, width=device-width'/>
           <meta name='description' content={description} />
-          <link rel="alternate" title="Events Detected by OONI" href="http://fastpath.ooni.nu:8080/rss/global.xml" type="application/rss+xml" />
+          <link rel="alternate" title="Events Detected by OONI" href="https://explorer.ooni.org/rss/global.xml" type="application/rss+xml" />
           <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicons/apple-icon-180x180.png" />
           <link rel="icon" type="image/png" sizes="192x192"  href="/static/images/favicons/android-icon-192x192.png" />
           <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicons/favicon-32x32.png" />

--- a/pages/country.js
+++ b/pages/country.js
@@ -109,6 +109,7 @@ export default class Country extends React.Component {
       <Layout>
         <Head>
           <title>Internet Censorship in {countryName} - OONI Explorer</title>
+          <link rel="alternate" title={`Events Detected in ${countryName} by OONI`} href={`https://explorer.ooni.org/rss/by-country/${countryCode}.xml`} type="application/rss+xml" />
         </Head>
         <StickyContainer>
           <Sticky>


### PR DESCRIPTION
This provides RSS feeds to subscribe to events detected by 'fastpath' (a component in the pipeline). The following different feeds will be made available:
- [x] A global feed added too all pages
- [x] A country wide feed added to the country pages

Fixes #330 