### PR TITLE
Release 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+## [2.0.4] - 2019-11-27
+
+### Added
+- Added this changelog
+- Added 'UTC' label to measurement timestamps (#328)
+- Added explorer version in footer (#329)
+- Added link to fastpath event detector feed (#342)
+
+### Changed
+- Refactored all file names exporting components to PascalCase format (#336)
+- Multiple dependency upgrades via dependabot
+
+### Fixed
+- Use the correct icon for Vanilla Tor section on country page (#327)
+- Replace deprecated `fuschia` color with `fuchsia` (#337)
+- Fix minor bug by removing unused code (#340)
+
+## [2.0.3] - 2019-09-25
+
+### Changed
+- Improve error reporting for failed searches
+
+### Fixed
+- Fixed bug in manual entry of date fields in search (#313)
+
+### Removed
+- Removed `BETA` from feedback modal title
+
+## [2.0.2] - 2019-09-12
+
+### Removed
+- Dropped card for Malaysia under LGBTQI block hightlights
+
+## [2.0.1] - 2019-09-12
+
+### Added
+- Added description to measurement coverage graph
+-
+
+### Changed
+- Update link to Malaysian event in highlights
+- Fix the canonical explorer link
+- Fix spacing and padding
+
+### Removed
+- Remove unused code, images, references to globe/atlas/map
+- Stop serving from `/data` directory. This was used temporarily during development
+
+## [2.0.0] - 2019-09-12
+
+### Added
+- First public release ([Blog post](https://ooni.org/post/next-generation-ooni-explorer/))
+
+[2.0.4]: (https://github.com/ooni/explorer/compare/v2.0.3...v2.0.4)
+[2.0.3]: (https://github.com/ooni/explorer/compare/v2.0.2...v2.0.3)
+[2.0.2]: (https://github.com/ooni/explorer/compare/v2.0.1...v2.0.2)
+[2.0.1]: (https://github.com/ooni/explorer/compare/v2.0.0...v2.0.1)
+[2.0.0]: (https://github.com/ooni/explorer/releases/tag/v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-explorer",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "license": "BSD-3-Clause",
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2649,11 +2649,6 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
-  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
-
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -3610,7 +3605,7 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -3706,29 +3701,13 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.9.0:
+js-yaml@^3.13.1, js-yaml@^3.9.0, js-yaml@^3.9.1, js-yaml@~3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^3.9.1:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@~3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
-  integrity sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
 
 jsesc@^2.5.1:
   version "2.5.1"
@@ -5725,20 +5704,10 @@ set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+set-value@^0.4.3, set-value@^2.0.0, set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"


### PR DESCRIPTION
### Added
- Added this changelog
- Added 'UTC' label to measurement timestamps (#328)
- Added explorer version in footer (#329)
- Added link to fastpath event detector feed (#342)

### Changed
- Refactored all file names exporting components to PascalCase format (#336)
- Multiple dependency upgrades via dependabot

### Fixed
- Use the correct icon for Vanilla Tor section on country page (#327)
- Replace deprecated `fuschia` color with `fuchsia` (#337)
- Fix minor bug by removing unused code (#340)
