### PR TITLE
Fix multiple API requests on search page

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -208,6 +208,15 @@ class Search extends React.Component {
     this.loadMore = this.loadMore.bind(this)
   }
 
+  componentDidMount () {
+    const { query, replace } = this.props.router
+    const href = {
+      pathname: '/search',
+      query
+    }
+    replace(href, href, { shallow: true })
+  }
+
   shouldComponentUpdate (nextProps, nextState) {
     if (this.props != nextProps) {
       return true

--- a/pages/search.js
+++ b/pages/search.js
@@ -201,22 +201,11 @@ class Search extends React.Component {
       search: null,
       error: props.error,
 
-      loading: true
+      loading: false
     }
     this.getFilterQuery = this.getFilterQuery.bind(this)
     this.onApplyFilter = this.onApplyFilter.bind(this)
     this.loadMore = this.loadMore.bind(this)
-  }
-
-  componentDidMount () {
-    const { query, replace } = this.props.router
-    replace({
-      pathname: '/search',
-      query
-    })
-    this.setState({
-      loading: false
-    })
   }
 
   shouldComponentUpdate (nextProps, nextState) {

--- a/pages/search.js
+++ b/pages/search.js
@@ -245,10 +245,11 @@ class Search extends React.Component {
       ...state
     }, () => {
       const query = this.getFilterQuery()
-      this.props.router.push({
+      const href = {
         pathname: '/search',
         query
-      }).then(() => {
+      }
+      this.props.router.push(href, href, { shallow: true }).then(() => {
         // XXX do error handling
         getMeasurements(query)
           .then((res) => {


### PR DESCRIPTION
To update the URL as we update search filters, we were using `Router.push` that triggered navigation, which in turn called `getInitialProps` and the API requests right after they were already initiated in `onApplyChange`.

The solution according to this [spectrum-chat](https://spectrum.chat/next-js/general/change-url-without-triggering-navigation~12ba234c-ad05-4783-8342-8a4a07661a9c) is to perform a shallow ~rendering~ routing which updates the URL without navigation.

Fixes #350 