### PR TITLE
Fixes the until today logic to include measurements today

### DIFF
--- a/components/country/AppsStatsRow.js
+++ b/components/country/AppsStatsRow.js
@@ -36,10 +36,10 @@ const StyledRow = styled(Box)`
 
 const NetworkRow = ({ asn, app }) => {
   const { countryCode } = useContext(CountryContext)
-  const today = moment().format('YYYY-MM-DD')
+  const until = moment().add(1, 'day').format('YYYY-MM-DD')
   const since = moment().subtract(30, 'days').format('YYYY-MM-DD')
 
-  const linkToMeasurements = `/search?probe_cc=${countryCode}&probe_asn=AS${asn}&test_name=${app}&since=${since}&until=${today}`
+  const linkToMeasurements = `/search?probe_cc=${countryCode}&probe_asn=AS${asn}&test_name=${app}&since=${since}&until=${until}`
 
   return (
     <Box width={1}>

--- a/components/country/URLChart.js
+++ b/components/country/URLChart.js
@@ -158,7 +158,7 @@ class URLChart extends React.Component {
       )
     }
 
-    const today = moment().format('YYYY-MM-DD')
+    const until = moment().add(1, 'day').format('YYYY-MM-DD')
     const since30days = moment().subtract(30, 'days').format('YYYY-MM-DD')
 
     const yMax = data.reduce((max, item) => (
@@ -174,7 +174,7 @@ class URLChart extends React.Component {
             <Box width={[1, 1/4]} p={3}>
               <TruncatedURL url={metadata.input} />
               <Link
-                href={`/search?test_name=web_connectivity&probe_cc=${countryCode}&probe_asn=${network}&domain=${domainToExplore}&since=${since30days}&until=${today}`}
+                href={`/search?test_name=web_connectivity&probe_cc=${countryCode}&probe_asn=${network}&domain=${domainToExplore}&since=${since30days}&until=${until}`}
               >
                 <FormattedMessage id='Country.Websites.URLCharts.ExploreMoreMeasurements' />
               </Link>

--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -50,7 +50,7 @@ class FilterSidebar extends React.Component {
     super(props)
 
     // Display `${today}` as the end date for default search
-    const today = moment().format('YYYY-MM-DD')
+    const until = moment().add(1, 'day').format('YYYY-MM-DD')
 
     this.state = {
       domainFilter: props.domainFilter || '',
@@ -59,7 +59,7 @@ class FilterSidebar extends React.Component {
       countryFilter: props.countryFilter || '',
       asnFilter: props.asnFilter || '',
       sinceFilter: props.sinceFilter || '',
-      untilFilter: props.untilFilter || today,
+      untilFilter: props.untilFilter || until,
       showSinceCalendar: true,
       showUntilCalendar: false,
       isFilterDirty: false,

--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -49,7 +49,8 @@ class FilterSidebar extends React.Component {
   constructor(props) {
     super(props)
 
-    // Display `${today}` as the end date for default search
+    // Display `${tomorrow}` as the end date for default search
+    // to include the measurements of `${today}` as well.
     const until = moment().add(1, 'day').format('YYYY-MM-DD')
 
     this.state = {

--- a/pages/search.js
+++ b/pages/search.js
@@ -133,9 +133,9 @@ class Search extends React.Component {
     // By default, on '/search' show measurements published until today
     // This prevents the search page from showing time-travelling future
     // measurements from showing up
-    const today = moment().format('YYYY-MM-DD')
+    const until = moment().add(1, 'day').format('YYYY-MM-DD')
     if (!query.until) {
-      query.until = today
+      query.until = until
     }
 
     [testNamesR, countriesR] = await Promise.all([

--- a/pages/search.js
+++ b/pages/search.js
@@ -131,6 +131,7 @@ class Search extends React.Component {
     let client = axios.create({baseURL: process.env.MEASUREMENTS_URL})  // eslint-disable-line
 
     // By default, on '/search' show measurements published until today
+    // including the measurements of today (so the date of tomorrow).
     // This prevents the search page from showing time-travelling future
     // measurements from showing up
     const until = moment().add(1, 'day').format('YYYY-MM-DD')


### PR DESCRIPTION
Fixes #361 

I have changed the `today` value everywhere to add 1 day so that the filter includes today's measurements. In doing so, I have changed the name of the variable from `today` to `until` which is something I saw used in the API repository. `today` sounded like a bad variable name, since clearly it's `tomorrow`. I am up to changing the variable name from `until` to something like `tomorrow` or `untilToday` if you all feel that's more suitable/relevant.