### PR TITLE
Release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.5] - 2020-01-09
+
+### Added
+- Added regex to allow search by IP address in the domain field (#367)
+- Added matomo based analytics (#369)
+
+### Fixed
+- Fixed bug where duplicate API requests were made for search queries (#353)
+- Fixed bug in rendering DNS queries on WebConnectivity measurement pages (#363)
+- Fixed 'until today' logic in search to include today's measurement (#364)
+
 ## [2.0.4] - 2019-11-27
 
 ### Added
@@ -53,6 +64,7 @@
 ### Added
 - First public release ([Blog post](https://ooni.org/post/next-generation-ooni-explorer/))
 
+[2.0.5]: (https://github.com/ooni/explorer/compare/v2.0.4...v2.0.5)
 [2.0.4]: (https://github.com/ooni/explorer/compare/v2.0.3...v2.0.4)
 [2.0.3]: (https://github.com/ooni/explorer/compare/v2.0.2...v2.0.3)
 [2.0.2]: (https://github.com/ooni/explorer/compare/v2.0.1...v2.0.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-explorer",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "license": "BSD-3-Clause",
   "main": "index.js",


### PR DESCRIPTION
### Added
- Added regex to allow search by IP address in the domain field (#367)
- Added matomo based analytics (#369)

### Fixed
- Fixed bug where duplicate API requests were made for search queries (#353)
- Fixed bug in rendering DNS queries on WebConnectivity measurement pages (#363)
- Fixed 'until today' logic in search to include today's measurement (#364)

