### PR TITLE
Ignore anomaly flag from fastpath

### DIFF
--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -251,7 +251,11 @@ QueryContainer.propTypes = {
 
 const WebConnectivityDetails = ({
   isConfirmed,
-  isAnomaly,
+  // NOTE: We stop using the `isAnomaly` flag coming from `/api/v1/measurements`
+  // because it causes this bug https://github.com/ooni/explorer/issues/374
+  // where measurements are marked anomaly despite `accessible: true, blocking: false`
+  //
+  // isAnomaly,
   isFailure,
   country,
   measurement,
@@ -321,7 +325,9 @@ const WebConnectivityDetails = ({
         }}
       />
     )
-  } else if (isAnomaly) {
+  } else if (/* isAnomaly */ blocking !== false) {
+    // We ignore the isAnomaly value from the API to work around
+    // https://github.com/ooni/explorer/issues/374
     status = 'anomaly'
     reason = intl.formatMessage(messages[`blockingReason.${blocking}`])
     summaryText = (
@@ -495,7 +501,7 @@ const WebConnectivityDetails = ({
 
 WebConnectivityDetails.propTypes = {
   isConfirmed: PropTypes.bool.isRequired,
-  isAnomaly: PropTypes.bool.isRequired,
+  // isAnomaly: PropTypes.bool.isRequired,
   isFailure: PropTypes.bool.isRequired,
   country: PropTypes.string.isRequired,
   measurement: PropTypes.object.isRequired,


### PR DESCRIPTION
To work around the misalignment of anomaly detection logic between fastpath, pipeline and explorer

Currently, fastpath detects anomalies with a logic different from that of legacy pipeline. Resulting in measurements being flagged as anomalies in the search result, although the values in `test_keys` do not point to an anomaly.

This fix works around that problem by using the values in `test_keys` to determine if the measurement is an anomaly or not.

Fixes #374