### PR TITLE
Make the blockingReason key fetch more robust

### DIFF
--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -329,7 +329,7 @@ const WebConnectivityDetails = ({
     // We ignore the isAnomaly value from the API to work around
     // https://github.com/ooni/explorer/issues/374
     status = 'anomaly'
-    reason = intl.formatMessage(messages[`blockingReason.${blocking}`])
+    reason = messages[`blockingReason.${blocking}`] && intl.formatMessage(messages[`blockingReason.${blocking}`])
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.Anomaly'
@@ -338,7 +338,7 @@ const WebConnectivityDetails = ({
           WebsiteURL: input,
           network: probe_asn,
           country: country,
-          BlockingReason: <strong>{intl.formatMessage(messages[`blockingReason.${blocking}`])}</strong>
+          BlockingReason: <strong>{messages[`blockingReason.${blocking}`] && intl.formatMessage(messages[`blockingReason.${blocking}`])}</strong>
         }}
       />
     )


### PR DESCRIPTION
Here is an example measurement which triggers this error: https://explorer.ooni.org/measurement/20170605T124503Z_AS0_eVo3z6wXAYDVrAZDsgqiM7pPlLuKR7l4zNF8oEUrGmZ62HWU4l?input=http:%2F%2Frockettube.com