### PR TITLE
Fix inconsistent msmt pages

### DIFF
--- a/components/measurement/SummaryText.js
+++ b/components/measurement/SummaryText.js
@@ -33,7 +33,6 @@ const SummaryText = ({
   } else {
     textToRender = content
   }
-  console.log(textToRender)
   return (
     <Text py={4} fontSize={20}>
       {textToRender}

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -251,11 +251,7 @@ QueryContainer.propTypes = {
 
 const WebConnectivityDetails = ({
   isConfirmed,
-  // NOTE: We stop using the `isAnomaly` flag coming from `/api/v1/measurements`
-  // because it causes this bug https://github.com/ooni/explorer/issues/374
-  // where measurements are marked anomaly despite `accessible: true, blocking: false`
-  //
-  // isAnomaly,
+  isAnomaly,
   isFailure,
   country,
   measurement,
@@ -324,9 +320,7 @@ const WebConnectivityDetails = ({
         }}
       />
     )
-  } else if (/* isAnomaly */ blocking !== false) {
-    // We ignore the isAnomaly value from the API to work around
-    // https://github.com/ooni/explorer/issues/374
+  } else if (isAnomaly) {
     status = 'anomaly'
     summaryText = (
       <FormattedMessage
@@ -496,7 +490,7 @@ const WebConnectivityDetails = ({
 
 WebConnectivityDetails.propTypes = {
   isConfirmed: PropTypes.bool.isRequired,
-  // isAnomaly: PropTypes.bool.isRequired,
+  isAnomaly: PropTypes.bool.isRequired,
   isFailure: PropTypes.bool.isRequired,
   country: PropTypes.string.isRequired,
   measurement: PropTypes.object.isRequired,

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -287,10 +287,10 @@ const WebConnectivityDetails = ({
     'tcp_ip': 'TCP'
   }
 
-  let status = 'default',
-    // XXX: `reason` will soon be used in Hero
-    reason = null,
-    summaryText = ''
+  let status = 'default'
+  let summaryText = ''
+
+  const reason = messages[`blockingReason.${blocking}`] && intl.formatMessage(messages[`blockingReason.${blocking}`])
 
   // TODO: Disabled temporarily because `isFailure` is flagged incorrectly in
   // some measurments. When fixed, this should be uncommented and the last
@@ -313,7 +313,6 @@ const WebConnectivityDetails = ({
   // } else
   if(isConfirmed) {
     status = 'confirmed'
-    reason = blocking && intl.formatMessage(messages[`blockingReason.${blocking}`])
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.ConfirmedBlocked'
@@ -329,7 +328,6 @@ const WebConnectivityDetails = ({
     // We ignore the isAnomaly value from the API to work around
     // https://github.com/ooni/explorer/issues/374
     status = 'anomaly'
-    reason = messages[`blockingReason.${blocking}`] && intl.formatMessage(messages[`blockingReason.${blocking}`])
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.Anomaly'
@@ -338,13 +336,12 @@ const WebConnectivityDetails = ({
           WebsiteURL: input,
           network: probe_asn,
           country: country,
-          BlockingReason: <strong>{messages[`blockingReason.${blocking}`] && intl.formatMessage(messages[`blockingReason.${blocking}`])}</strong>
+          BlockingReason: reason && <strong>{reason}</strong>
         }}
       />
     )
   } else if (accessible) {
     status = 'reachable'
-    reason = null
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.Accessible'
@@ -359,7 +356,6 @@ const WebConnectivityDetails = ({
   } else if (blocking === false) {
     // When not accessible, but also not blocking, it must be down
     status = 'down'
-    reason = 'down'
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.Down'
@@ -374,7 +370,6 @@ const WebConnectivityDetails = ({
   } else {
     // TODO: Remove this block when the first block in this chain is enabled.
     status = 'error'
-    reason = null
     summaryText = (
       <FormattedMessage
         id='Measurement.SummaryText.Websites.Failed'

--- a/pages/measurement.js
+++ b/pages/measurement.js
@@ -50,7 +50,7 @@ export default class Measurement extends React.Component {
       initialProps['isAnomaly'] = results[0].anomaly
       initialProps['isFailure'] = results[0].failure
       initialProps['isConfirmed'] = results[0].confirmed
-      initialProps['message'] = results[0].scores.msg || null
+      initialProps['scores'] = results[0].scores || null
       const countryObj = countryUtil.countryList.find(country => (
         country.iso3166_alpha2 === msmtContent.data.probe_cc
       ))
@@ -67,6 +67,7 @@ export default class Measurement extends React.Component {
   render () {
     let {
       measurement,
+      scores,
       country,
       measurementURL,
       isConfirmed,
@@ -85,6 +86,7 @@ export default class Measurement extends React.Component {
           isFailure={isFailure}
           country={country}
           measurement={measurement}
+          scores={scores}
           render={({
             status = 'default',
             statusIcon,

--- a/pages/measurement.js
+++ b/pages/measurement.js
@@ -50,7 +50,7 @@ export default class Measurement extends React.Component {
       initialProps['isAnomaly'] = results[0].anomaly
       initialProps['isFailure'] = results[0].failure
       initialProps['isConfirmed'] = results[0].confirmed
-
+      initialProps['message'] = results[0].scores.msg || null
       const countryObj = countryUtil.countryList.find(country => (
         country.iso3166_alpha2 === msmtContent.data.probe_cc
       ))


### PR DESCRIPTION
This PR contains proposed fixes to the issues discussed recently.
* Restructuring the code in `WebConnectivity.js` measurement page component
* Injecting the message from `scores.msg` for WhatsApp measurement pages