### PR TITLE
Handle cases where test_keys.tcp_connect is missing

### DIFF
--- a/components/measurement/nettests/Telegram.js
+++ b/components/measurement/nettests/Telegram.js
@@ -73,8 +73,8 @@ const TelegramDetails = ({ measurement, render }) => {
                       />
                     </Box>
                   </Flex>
-                  {tcp_connect.length > 0 &&
-                    <React.Fragment>
+                  {tcp_connect && tcp_connect.length > 0 &&
+                    <div>
                       <Heading h={4}> <FormattedMessage id='Measurement.Details.Telegram.Endpoint.Status.Heading' /> </Heading>
                       {tcp_connect.map((connection, index) => (
                         <Flex key={index}>
@@ -94,7 +94,7 @@ const TelegramDetails = ({ measurement, render }) => {
                           </Box>
                         </Flex>
                       ))}
-                    </React.Fragment>
+                    </div>
                   }
                 </React.Fragment>
               } />

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -266,7 +266,7 @@ const WebConnectivityDetails = ({
       accessible,
       blocking,
       queries,
-      tcp_connect,
+      tcp_connect = [],
       requests,
       client_resolver,
       http_experiment_failure,


### PR DESCRIPTION
Fixes #381 

Addresses the issue in Telegram and WebConnectivity pages. Other places where this key is used are covered already:
[FacebookMessenger.js](https://github.com/ooni/explorer/blob/master/components/measurement/nettests/FacebookMessenger.js#L75)
[WhatsApp.js](https://github.com/ooni/explorer/blob/master/components/measurement/nettests/WhatsApp.js#L89)

Are there other keys from the spec that could go missing? Or is this only specific to `miniooni` generated measurements?