### PR TITLE
Improved meta in country pages

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -26,8 +26,8 @@ export default class Header extends React.Component {
           <meta name="twitter:site" content="@openobservatory" />
           <meta name="twitter:creator" content="@openobservatory" />
 
-          <meta name='og:title' property='og:title' content='OONI Explorer - Open Data on Internet Censorship Worldwide' />
-          <meta property="og:description" content={description} />
+          <meta key="og:title" name='og:title' property='og:title' content='OONI Explorer - Open Data on Internet Censorship Worldwide' />
+          <meta key="og:description" property="og:description" content={description} />
           <meta property='og:type' content='website' />
 
         </Head>

--- a/components/country/IntlHead.js
+++ b/components/country/IntlHead.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import Head from 'next/head'
+import { useIntl } from 'react-intl'
+
+const IntlHead = ({
+  countryName,
+  measurementCount,
+  measuredSince,
+  networkCount
+}) => {
+  const intl = useIntl()
+  return (
+    <Head>
+      <title>Internet Censorship in {countryName} - OONI Explorer</title>
+      <meta
+        key="og:title"
+        property="og:title"
+        content={intl.formatMessage(
+          {
+            id: 'Country.Overview.MetaTitle',
+            defaultMessage: 'Internet Censorship in {countryName} - OONI Explorer'
+          },
+          {
+            countryName
+          }
+        )}
+      />
+      <meta
+        key="og:description"
+        property="og:description"
+        content={intl.formatMessage(
+          {
+            id: 'Country.Overview.MetaDescription',
+            defaultMessage:
+            'Since {startDate}, OONI Probe users in {countryName} have collected {measurementCount} measurements from {networkCount} local networks. Explore the data on OONI Explorer'
+          },
+          {
+            measurementCount: intl.formatNumber(measurementCount),
+            countryName,
+            startDate: intl.formatDate(measuredSince),
+            networkCount: intl.formatNumber(networkCount)
+          }
+        )}
+      />
+    </Head>
+  )
+}
+
+export default IntlHead

--- a/pages/country.js
+++ b/pages/country.js
@@ -1,6 +1,5 @@
 /* global process */
 import React from 'react'
-import Head from 'next/head'
 import axios from 'axios'
 import {
   Container,
@@ -21,7 +20,7 @@ import WebsitesSection from '../components/country/Websites'
 import AppsSection from '../components/country/Apps'
 import NetworkPropertiesSection from '../components/country/NetworkProperties'
 import { CountryContextProvider } from '../components/country/CountryContext'
-import { useIntl } from 'react-intl'
+import IntlHead from '../components/country/IntlHead'
 
 const getCountryReports = (countryCode, data) => {
   const reports = data.filter((article) => (
@@ -44,50 +43,6 @@ const AnimatedFlex = styled(Flex)`
 const AnimatedHeading = styled(Heading)`
   transition: all 0.5s ease;
 `
-const IntlHead = ({
-  countryName,
-  measurementCount,
-  measuredSince,
-  networkCount
-}) => {
-  const intl = useIntl()
-  return (
-    <Head>
-      <title>Internet Censorship in {countryName} - OONI Explorer</title>
-      <meta
-        key="og:title"
-        property="og:title"
-        content={intl.formatMessage(
-          {
-            id: 'Country.Overview.MetaTitle',
-            defaultMessage: 'Internet Censorship in {countryName} - OONI Explorer'
-          },
-          {
-            countryName
-          }
-        )}
-      />
-      <meta
-        key="og:description"
-        property="og:description"
-        content={intl.formatMessage(
-          {
-            id: 'Country.Overview.MetaDescription',
-            defaultMessage:
-            'Since {startDate}, OONI Probe users in {countryName} have collected {measurementCount} measurements from {networkCount} local networks. Explore the data on OONI Explorer'
-          },
-          {
-            measurementCount: intl.formatNumber(measurementCount),
-            countryName,
-            startDate: intl.formatDate(measuredSince),
-            networkCount: intl.formatNumber(networkCount)
-          }
-        )}
-      />
-    </Head>
-  )
-}
-
 export default class Country extends React.Component {
   static async getInitialProps ({ query }) {
     const { countryCode } = query
@@ -144,7 +99,7 @@ export default class Country extends React.Component {
       countryCode,
       countryName,
       overviewStats,
-      reports,
+      reports
     } = this.props
 
     const { testCoverage, networkCoverage } = this.state.newData ? this.state.newData : this.props

--- a/pages/country.js
+++ b/pages/country.js
@@ -21,6 +21,7 @@ import WebsitesSection from '../components/country/Websites'
 import AppsSection from '../components/country/Apps'
 import NetworkPropertiesSection from '../components/country/NetworkProperties'
 import { CountryContextProvider } from '../components/country/CountryContext'
+import { useIntl } from 'react-intl'
 
 const getCountryReports = (countryCode, data) => {
   const reports = data.filter((article) => (
@@ -43,6 +44,49 @@ const AnimatedFlex = styled(Flex)`
 const AnimatedHeading = styled(Heading)`
   transition: all 0.5s ease;
 `
+const IntlHead = ({
+  countryName,
+  measurementCount,
+  measuredSince,
+  networkCount
+}) => {
+  const intl = useIntl()
+  return (
+    <Head>
+      <title>Internet Censorship in {countryName} - OONI Explorer</title>
+      <meta
+        key="og:title"
+        property="og:title"
+        content={intl.formatMessage(
+          {
+            id: 'Country.Overview.MetaTitle',
+            defaultMessage: 'Internet Censorship in {countryName} - OONI Explorer'
+          },
+          {
+            countryName
+          }
+        )}
+      />
+      <meta
+        key="og:description"
+        property="og:description"
+        content={intl.formatMessage(
+          {
+            id: 'Country.Overview.MetaDescription',
+            defaultMessage:
+            'Since {startDate}, OONI Probe users in {countryName} have collected {measurementCount} measurements from {networkCount} local networks. Explore the data on OONI Explorer'
+          },
+          {
+            measurementCount: intl.formatNumber(measurementCount),
+            countryName,
+            startDate: intl.formatDate(measuredSince),
+            networkCount: intl.formatNumber(networkCount)
+          }
+        )}
+      />
+    </Head>
+  )
+}
 
 export default class Country extends React.Component {
   static async getInitialProps ({ query }) {
@@ -100,17 +144,14 @@ export default class Country extends React.Component {
       countryCode,
       countryName,
       overviewStats,
-      reports
+      reports,
     } = this.props
 
     const { testCoverage, networkCoverage } = this.state.newData ? this.state.newData : this.props
 
     return (
       <Layout>
-        <Head>
-          <title>Internet Censorship in {countryName} - OONI Explorer</title>
-          <link rel="alternate" title={`Events Detected in ${countryName} by OONI`} href={`https://explorer.ooni.org/rss/by-country/${countryCode}.xml`} type="application/rss+xml" />
-        </Head>
+        <IntlHead countryName={countryName} measurementCount={overviewStats.network_count} measuredSince={overviewStats.first_bucket_date} networkCount={overviewStats.network_count} />
         <StickyContainer>
           <Sticky>
             {({ style, distanceFromTop }) => {
@@ -168,3 +209,4 @@ export default class Country extends React.Component {
     )
   }
 }
+


### PR DESCRIPTION
Helps with #202 

- Changed the og:description to show a summary of the measurements about the country
- Changed the og:title to show the appropriate title with current country's name in it

Possible improvements: use Intl strings instead of plain english