### PR TITLE
Implemented measurement page for Ndt7

### DIFF
--- a/components/measurement/PerformanceDetails.js
+++ b/components/measurement/PerformanceDetails.js
@@ -13,14 +13,14 @@ const PerformanceDetails = ({
   timeouts
 }) => {
   const intl = useIntl()
-  const items = [
+  let items = [
     {
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.AvgPing' }),
       value: averagePing.toString() + ' ms'
     },
     {
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MaxPing' }),
-      value: isNdt7 ? `~${maxPing.toString()} ms` : `${maxPing.toString()}ms`
+      value: `${isNdt7 ? '~' : ''}${maxPing.toString()} ms`
     },
     {
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MSS' }),
@@ -28,22 +28,27 @@ const PerformanceDetails = ({
     },
     {
       label: isNdt7 ? intl.formatMessage({
-          id: 'Measurement.Details.Performance.Label.RetransmitRate',
-          defaultMessage: 'RetransmitRate'
+        id: 'Measurement.Details.Performance.Label.RetransmitRate',
+        defaultMessage: 'Retransmit Rate'
       }): intl.formatMessage({ id: 'Measurement.Details.Performance.Label.PktLoss' }),
       value: packetLoss.toString() + '%'
     },
-    ...(isNdt7 ? [] : //only adds outOfOrder and  timeouts if isNdt7 is false
-      [{
-          label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.OutOfOrder' }),
+  ]
+
+  //Only add outOfOrder and timeouts if NDT4/5 measurement
+  if(!isNdt7){
+    items = items.concat([
+      {
+        label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.OutOfOrder' }),
         value: outOfOrder.toString() + '%'
       },
       {
         label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.Timeouts' }),
         value: timeouts.toString()
-      }]
-    )
-  ]
+      }
+    ])
+  }
+
   return (
     <DetailsBoxTable
       title={intl.formatMessage({ id: 'Measurement.Details.Performance.Heading' })}

--- a/components/measurement/PerformanceDetails.js
+++ b/components/measurement/PerformanceDetails.js
@@ -4,10 +4,13 @@ import { useIntl } from 'react-intl'
 import { DetailsBoxTable } from './DetailsBox'
 
 const PerformanceDetails = ({
+  isNdt7,
   averagePing,
   maxPing,
   mss,
   packetLoss,
+  outOfOrder,
+  timeouts
 }) => {
   const intl = useIntl()
   const items = [
@@ -17,16 +20,29 @@ const PerformanceDetails = ({
     },
     {
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MaxPing' }),
-      value: '~' + maxPing.toString() + ' ms'
+      value: isNdt7 ? `~${maxPing.toString()} ms` : `${maxPing.toString()}ms`
     },
     {
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MSS' }),
       value: mss.toString()
     },
     {
-      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.PktLoss' }),
+      label: isNdt7 ? intl.formatMessage({
+          id: 'Measurement.Details.Performance.Label.RetransmitRate',
+          defaultMessage: 'RetransmitRate'
+      }): intl.formatMessage({ id: 'Measurement.Details.Performance.Label.PktLoss' }),
       value: packetLoss.toString() + '%'
     },
+    ...(isNdt7 ? [] : //only adds outOfOrder and  timeouts if isNdt7 is false
+      [{
+          label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.OutOfOrder' }),
+        value: outOfOrder.toString() + '%'
+      },
+      {
+        label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.Timeouts' }),
+        value: timeouts.toString()
+      }]
+    )
   ]
   return (
     <DetailsBoxTable
@@ -38,10 +54,13 @@ const PerformanceDetails = ({
 }
 
 PerformanceDetails.propTypes = {
+  isNdt7: PropTypes.bool.isRequired,
   averagePing: PropTypes.number.isRequired,
   maxPing: PropTypes.number.isRequired,
   mss: PropTypes.number.isRequired,
   packetLoss: PropTypes.number.isRequired,
+  outOfOrder: PropTypes.number.isRequired,
+  timeouts: PropTypes.number.isRequired
 }
 
 export default PerformanceDetails

--- a/components/measurement/PerformanceDetails.js
+++ b/components/measurement/PerformanceDetails.js
@@ -8,8 +8,6 @@ const PerformanceDetails = ({
   maxPing,
   mss,
   packetLoss,
-  outOfOrder,
-  timeouts
 }) => {
   const intl = useIntl()
   const items = [
@@ -19,7 +17,7 @@ const PerformanceDetails = ({
     },
     {
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MaxPing' }),
-      value: maxPing.toString() + ' ms'
+      value: '~' + maxPing.toString() + ' ms'
     },
     {
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MSS' }),
@@ -29,14 +27,6 @@ const PerformanceDetails = ({
       label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.PktLoss' }),
       value: packetLoss.toString() + '%'
     },
-    {
-      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.OutOfOrder' }),
-      value: outOfOrder.toString() + '%'
-    },
-    {
-      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.Timeouts' }),
-      value: timeouts.toString()
-    }
   ]
   return (
     <DetailsBoxTable
@@ -52,8 +42,6 @@ PerformanceDetails.propTypes = {
   maxPing: PropTypes.number.isRequired,
   mss: PropTypes.number.isRequired,
   packetLoss: PropTypes.number.isRequired,
-  outOfOrder: PropTypes.number.isRequired,
-  timeouts: PropTypes.number.isRequired
 }
 
 export default PerformanceDetails

--- a/components/measurement/nettests/Ndt.js
+++ b/components/measurement/nettests/Ndt.js
@@ -30,14 +30,14 @@ const ServerLocation = ({ serverAddress, isNdt7 }) => {
   const server = mlabServerDetails(serverAddress, isNdt7)
 
   return (
-    <React.Fragment> {
-      server
-        ? `${server.city}, ${server.countryName}`
-        : 'N/A'
-    } </React.Fragment>
+    <React.Fragment>
+      {server ? `${server.city}, ${server.countryName}` : 'N/A'}
+    </React.Fragment>
   )
 }
 
+// NdtDetails is implemented differently for Ndt4/5 and for Ndt7 hence
+// the use of isNdt7.See https://github.com/ooni/explorer/issues/452
 const NdtDetails = ({ measurement, render }) => {
   const intl = useIntl()
   const testKeys = measurement.test_keys
@@ -97,9 +97,9 @@ const NdtDetails = ({ measurement, render }) => {
               <InfoBoxItem
                 label={intl.formatMessage({ id: 'Measurement.Status.Info.Label.Server' })}
                 content={<ServerLocation
-                    serverAddress={isNdt7 ? testKeys.server.hostname : testKeys.server_address}
-                    isNdt7={isNdt7}
-                  />}
+                  serverAddress={isNdt7 ? testKeys.server.hostname : testKeys.server_address}
+                  isNdt7={isNdt7}
+                />}
               />
             </Flex>
           }

--- a/components/measurement/nettests/Ndt.js
+++ b/components/measurement/nettests/Ndt.js
@@ -37,7 +37,7 @@ const ServerLocation = ({ serverAddress, isNdt7 }) => {
 }
 
 // NdtDetails is implemented differently for Ndt4/5 and for Ndt7 hence
-// the use of isNdt7.See https://github.com/ooni/explorer/issues/452
+// the use of isNdt7. See https://github.com/ooni/explorer/issues/452
 const NdtDetails = ({ measurement, render }) => {
   const intl = useIntl()
   const testKeys = measurement.test_keys

--- a/components/measurement/nettests/Ndt.js
+++ b/components/measurement/nettests/Ndt.js
@@ -56,11 +56,9 @@ const NdtDetails = ({ measurement, render }) => {
 
   // Advanced
   const packetLoss = advanced.packet_loss && (advanced.packet_loss * 100).toFixed(3)
-  const outOfOrder = advanced.out_of_order && (advanced.out_of_order * 100).toFixed(1)
   const minRTT = advanced.min_rtt && (advanced.min_rtt).toFixed(0)
   const maxRTT = advanced.max_rtt && (advanced.max_rtt).toFixed(0)
   const mss = advanced.mss
-  const timeouts = advanced.timeouts
 
   // FIXME we need to style the failed test case properly
   return (
@@ -90,8 +88,6 @@ const NdtDetails = ({ measurement, render }) => {
             maxPing={maxRTT}
             mss={mss}
             packetLoss={packetLoss}
-            outOfOrder={outOfOrder}
-            timeouts={timeouts}
           />}
         </div>
       )

--- a/components/measurement/nettests/Ndt.js
+++ b/components/measurement/nettests/Ndt.js
@@ -26,8 +26,8 @@ const InfoBoxItem = ({
   </Box>
 )
 
-const ServerLocation = ({ serverAddress }) => {
-  const server = mlabServerDetails(serverAddress)
+const ServerLocation = ({ serverAddress, isNdt7 }) => {
+  const server = mlabServerDetails(serverAddress, isNdt7)
 
   return (
     <React.Fragment> {
@@ -38,15 +38,16 @@ const ServerLocation = ({ serverAddress }) => {
   )
 }
 
-
 const NdtDetails = ({ measurement, render }) => {
   const intl = useIntl()
   const testKeys = measurement.test_keys
   const isFailed = testKeys.failure !== null
   const failure = testKeys.failure
+  const isNdt7 = testKeys.protocol === 7
 
-  const simple = testKeys.simple || {}
-  const advanced = testKeys.advanced || {}
+  let packetLoss, minRTT, maxRTT, mss, outOfOrder, timeouts
+
+  const simple = (isNdt7 ? testKeys.summary : testKeys.simple) || {}
 
   // XXX we probably want to use a utility function to convert to other units,
   // ex. use kbit/s if the speed is low and gbit/s if it's high
@@ -54,11 +55,28 @@ const NdtDetails = ({ measurement, render }) => {
   const uploadMbit = simple.upload && (simple.upload / 1000).toFixed(2)
   const ping = simple.ping && (simple.ping).toFixed(1)
 
-  // Advanced
-  const packetLoss = advanced.packet_loss && (advanced.packet_loss * 100).toFixed(3)
-  const minRTT = advanced.min_rtt && (advanced.min_rtt).toFixed(0)
-  const maxRTT = advanced.max_rtt && (advanced.max_rtt).toFixed(0)
-  const mss = advanced.mss
+  if (isNdt7) {
+    const summary = testKeys.summary || {}
+
+    // Summary
+    packetLoss = summary.retransmit_rate && (summary.retransmit_rate * 100).toFixed(3)
+    minRTT = summary.min_rtt && (summary.min_rtt).toFixed(0)
+    maxRTT = summary.max_rtt && (summary.max_rtt).toFixed(0)
+    mss = summary.mss
+    outOfOrder = null
+    timeouts = null
+  }
+  else {
+    const advanced = testKeys.advanced || {}
+
+    // Advanced
+    packetLoss = advanced.packet_loss && (advanced.packet_loss * 100).toFixed(3)
+    outOfOrder = advanced.out_of_order && (advanced.out_of_order * 100).toFixed(1)
+    minRTT = advanced.min_rtt && (advanced.min_rtt).toFixed(0)
+    maxRTT = advanced.max_rtt && (advanced.max_rtt).toFixed(0)
+    mss = advanced.mss
+    timeouts = advanced.timeouts
+  }
 
   // FIXME we need to style the failed test case properly
   return (
@@ -76,7 +94,13 @@ const NdtDetails = ({ measurement, render }) => {
               <InfoBoxItem label={intl.formatMessage({ id: 'Measurement.Status.Info.Label.Download' })} content={downloadMbit} unit='Mbps' />
               <InfoBoxItem label={intl.formatMessage({ id: 'Measurement.Status.Info.Label.Upload' })} content={uploadMbit} unit='Mbps' />
               <InfoBoxItem label={intl.formatMessage({ id: 'Measurement.Status.Info.Label.Ping' })} content={ping} unit='ms' />
-              <InfoBoxItem label={intl.formatMessage({ id: 'Measurement.Status.Info.Label.Server' })} content={<ServerLocation serverAddress={testKeys.server_address} />} />
+              <InfoBoxItem
+                label={intl.formatMessage({ id: 'Measurement.Status.Info.Label.Server' })}
+                content={<ServerLocation
+                    serverAddress={isNdt7 ? testKeys.server.hostname : testKeys.server_address}
+                    isNdt7={isNdt7}
+                  />}
+              />
             </Flex>
           }
         </Box>
@@ -84,10 +108,13 @@ const NdtDetails = ({ measurement, render }) => {
       details: (
         <div> {!isFailed &&
           <PerformanceDetails
+            isNdt7={isNdt7}
             averagePing={ping}
             maxPing={maxRTT}
             mss={mss}
             packetLoss={packetLoss}
+            outOfOrder={outOfOrder}
+            timeouts={timeouts}
           />}
         </div>
       )

--- a/components/measurement/nettests/mlab_utils.js
+++ b/components/measurement/nettests/mlab_utils.js
@@ -2,8 +2,9 @@
 const MLAB_SERVERS = require('./mlab_servers.json')
 import countryUtil from 'country-util'
 
-export const mlabServerDetails = (serverAddress) => {
-  const serverNode = serverAddress.split('.')[3]
+export const mlabServerDetails = (serverAddress, isNdt7) => {
+  const serverNode = isNdt7 ? serverAddress.split('-')[3].split('.')[0] : serverAddress.split('.')[3]
+
   const server = MLAB_SERVERS.find((node) => node.site === serverNode)
   if (server) {
     server.countryName = countryUtil.territoryNames[server.country]


### PR DESCRIPTION
#452 

Changes done for Ndt7 measurements
- [x] updated packet loss to be retransmit rate
- [x] removed outoforder
- [x] showing a ~ with ping to show that its an estimate
- [x] removed timeout
- [x] Changed the method for getting server name

The Ndt4/5 measurements still look the same.

I tried to have as little replication of code as i could without making the code a mess to read.