### PR TITLE
overview charts are rendered in country page

### DIFF
--- a/components/country/OverviewCharts.js
+++ b/components/country/OverviewCharts.js
@@ -121,7 +121,7 @@ class TestsByGroup extends React.PureComponent {
     // Check if there is enough data to plot the charts
     const testCoverageCount = testCoverage.reduce((count, item) => count + item.count, 0)
     const networkCoverageCount = networkCoverage.reduce((count, item) => count + item.count, 0)
-    const notEnoughData = !(testCoverageCount === 0 && networkCoverageCount === 0)
+    const notEnoughData = (testCoverageCount === 0 && networkCoverageCount === 0)
 
     const supportedTestGroups = ['websites', 'im', 'middlebox', 'performance', 'circumvention']
 


### PR DESCRIPTION
This pull request fixes #458 
The overview charts in the country page are rendered .