### PR TITLE
Use blue7 for links

### DIFF
--- a/components/country/AppsStatsRow.js
+++ b/components/country/AppsStatsRow.js
@@ -57,9 +57,7 @@ const NetworkRow = ({ asn, app }) => {
               </strong>
             </Box>
             <Box>
-              <Link
-                href={linkToMeasurements}
-              >
+              <Link href={linkToMeasurements} color='blue7'>
                 <FormattedMessage id='Country.Websites.URLCharts.ExploreMoreMeasurements' />
               </Link>
             </Box>

--- a/components/country/URLChart.js
+++ b/components/country/URLChart.js
@@ -173,7 +173,7 @@ class URLChart extends React.Component {
           <Flex alignItems='center' flexWrap='wrap'>
             <Box width={[1, 1/4]} p={3}>
               <TruncatedURL url={metadata.input} />
-              <Link
+              <Link color='blue7'
                 href={`/search?test_name=web_connectivity&probe_cc=${countryCode}&probe_asn=${network}&domain=${domainToExplore}&since=${since30days}&until=${until}`}
               >
                 <FormattedMessage id='Country.Websites.URLCharts.ExploreMoreMeasurements' />

--- a/components/measurement/DetailsHeader.js
+++ b/components/measurement/DetailsHeader.js
@@ -44,7 +44,7 @@ const DetailsHeader = ({testName, runtime, notice}) => {
           />
         </Box>
         <Box ml={2}>
-          <Link href={metadata.info}>
+          <Link color='blue7' href={metadata.info}>
             <Text fontSize={20}>
               {metadata.name}
               &nbsp;


### PR DESCRIPTION
The `<Link>` component in ooni/design-system currently fails
to apply the default color for the link correctly. These changes
do this manually until the bug is fixed.
