### PR TITLE
Refactored measurement page using refactored API

### DIFF
--- a/components/measurement/CommonSummary.js
+++ b/components/measurement/CommonSummary.js
@@ -42,13 +42,15 @@ SummaryItemBox.propTypes = {
 
 const CommonSummary = ({
   color,
-  measurement,
+  test_start_time,
+  probe_asn,
+  probe_cc,
   country
 }) => {
   const intl = useIntl()
-  const startTime = measurement.test_start_time
-  const network = measurement.probe_asn
-  const countryCode = measurement.probe_cc
+  const startTime = test_start_time
+  const network = probe_asn
+  const countryCode = probe_cc
 
   const countryBlock = <Flex flexWrap='wrap'>
     <Box mr={2} pb={1} width={1}>

--- a/components/measurement/DetailsHeader.js
+++ b/components/measurement/DetailsHeader.js
@@ -57,9 +57,9 @@ const DetailsHeader = ({testName, runtime, notice}) => {
         {notice}
       </Box>
       <Box>
-        <Text fontSize={20}>
+        {runtime && <Text fontSize={20}>
           <FormattedMessage id='Measurement.DetailsHeader.Runtime' />: <Text is='span' fontWeight='bold'>{prettyMs(runtime * 1000)}</Text>
-        </Text>
+        </Text>}
       </Box>
     </Flex>
   )

--- a/components/measurement/DetailsHeader.js
+++ b/components/measurement/DetailsHeader.js
@@ -57,9 +57,11 @@ const DetailsHeader = ({testName, runtime, notice}) => {
         {notice}
       </Box>
       <Box>
-        <Text fontSize={20}>
-          <FormattedMessage id='Measurement.DetailsHeader.Runtime' />: <Text is='span' fontWeight='bold'>{prettyMs(runtime * 1000)}</Text>
-        </Text>
+        {runtime &&
+          <Text fontSize={20}>
+            <FormattedMessage id='Measurement.DetailsHeader.Runtime' />: <Text is='span' fontWeight='bold'>{prettyMs(runtime * 1000)}</Text>
+          </Text>
+        }
       </Box>
     </Flex>
   )

--- a/components/measurement/DetailsHeader.js
+++ b/components/measurement/DetailsHeader.js
@@ -57,9 +57,9 @@ const DetailsHeader = ({testName, runtime, notice}) => {
         {notice}
       </Box>
       <Box>
-        {runtime && <Text fontSize={20}>
+        <Text fontSize={20}>
           <FormattedMessage id='Measurement.DetailsHeader.Runtime' />: <Text is='span' fontWeight='bold'>{prettyMs(runtime * 1000)}</Text>
-        </Text>}
+        </Text>
       </Box>
     </Flex>
   )

--- a/components/measurement/MeasurementContainer.js
+++ b/components/measurement/MeasurementContainer.js
@@ -30,15 +30,9 @@ const mapTestDetails = {
   tor: TorDetails
 }
 
-// FIXME to have header and stuff
-const MeasurementNotFound = () => <h4>Measurement not Found</h4>
 
-const MeasurementContainer = ({ measurement, ...props }) => {
-  if (measurement === undefined) {
-    return <MeasurementNotFound />
-  }
-
-  const TestDetails = mapTestDetails[measurement.test_name] || DefaultTestDetails
+const MeasurementContainer = ({ testName, measurement, ...props }) => {
+  const TestDetails = measurement ? mapTestDetails[testName] : DefaultTestDetails
   return <TestDetails measurement={measurement} {...props} />
 }
 

--- a/components/measurement/MeasurementNotFound.js
+++ b/components/measurement/MeasurementNotFound.js
@@ -1,0 +1,29 @@
+/* global process */
+import React from 'react'
+import NavBar from '../NavBar'
+import { Container, Flex, Box, Heading, Text } from 'ooni-components'
+import { useRouter } from 'next/router'
+
+import OONI404 from '../../static/images/OONI_404.svg'
+
+const MeasurementNotFound = () => {
+  const { asPath } = useRouter()
+  return (
+    <React.Fragment>
+      <NavBar />
+      <Container>
+        <Flex justifyContent='space-around' alignItems='center' my={5}>
+          <OONI404 height='200px' />
+          <Box width={1/2}>
+            <Heading h={4}>Measurement Not Found</Heading>
+            <Text color='gray8'>
+              {`${process.env.EXPLORER_URL}${asPath}`}
+            </Text>
+          </Box>
+        </Flex>
+      </Container>
+    </React.Fragment>
+  )
+}
+
+export default MeasurementNotFound

--- a/components/measurement/nettests/Default.js
+++ b/components/measurement/nettests/Default.js
@@ -2,14 +2,31 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 
-const DefaultTestDetails = ({ measurement, render }) => (
-  render({
-    statusLabel: <FormattedMessage id='Measurement.Hero.Status.Default' />,
-  })
-)
+const DefaultTestDetails = ({
+  isConfirmed,
+  isAnomaly,
+  isFailure,
+  render
+}) => {
+  const status = isConfirmed ? (
+    'confirmed'
+  ) : (
+    isAnomaly ? (
+      'anomaly'
+    ) : (
+      isFailure ? (
+        'error'
+      ) : 'reachable'
+    )
+  )
+  return (
+    render({
+      status
+    })
+  )
+}
 
 DefaultTestDetails.propTypes = {
-  measurement: PropTypes.object,
   render: PropTypes.func
 }
 

--- a/cypress/integration/measurement.e2e.js
+++ b/cypress/integration/measurement.e2e.js
@@ -43,15 +43,15 @@ describe('Measurement Page Tests', () => {
       cy.visit('/measurement/20200304T203936Z_AS44869_bVdV4B2HXylbIS8nFmdYbXDsDa5gwmkJbF38uWEfus1MMpS5b6')
     })
 
-    // it('renders an anomaly measurement', () => {
-    //   cy.visit('')
-    // })
+    it('renders an anomaly measurement', () => {
+      cy.visit('/measurement/20200407T024309Z_AS4713_xA9Wh81DQrIFqRe46zwKeyJw4DJQwjyTLBIi2zSQqWUBsfQMJS')
+    })
   })
 
   describe('Facebook Messenger Tests', () => {
-    // it('renders an accessible measurement', () => {
-    //   cy.visit('')
-    // })
+    it('renders an accessible measurement', () => {
+      cy.visit('/measurement/20200407T235214Z_AS3269_EIlT6478yDwpzYNO8f54Xl12aN4AbkK82OuCUZSYHh3cTKNoYF')
+    })
 
     it('renders an anomaly measurement', () => {
       cy.visit('/measurement/20200304T191012Z_AS42610_fqDY31xiRoWEdKd4GWtV84UYpXG2RlpjBK7kd8rTLHIItqMnej')

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const dev = process.env.NODE_ENV === 'development'
 if (dev === true) {
   process.env.MEASUREMENTS_URL = process.env.MEASUREMENTS_URL || 'http://127.0.0.1:' + process.env.PORT
 } else {
-  process.env.MEASUREMENTS_URL = process.env.MEASUREMENTS_URL || 'https://api.ooni.io'
+  process.env.MEASUREMENTS_URL = process.env.MEASUREMENTS_URL || 'https://ams-pg.ooni.org'
 }
 if (!process.env.EXPLORER_URL) {
   process.env.EXPLORER_URL = 'http://127.0.0.1:' + process.env.PORT

--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ module.exports = withSourceMaps(withCSS({
   webpack: (config, {isServer}) => {
     config.plugins.push(
       new webpack.DefinePlugin({
-        'process.env.MEASUREMENTS_URL': JSON.stringify(process.env.MEASUREMENTS_URL || 'https://api.ooni.io'),
+        'process.env.MEASUREMENTS_URL': JSON.stringify(process.env.MEASUREMENTS_URL || 'https://ams-pg.ooni.org'),
         'process.env.EXPLORER_URL': JSON.stringify(process.env.EXPLORER_URL  || 'http://127.0.0.1:' + process.env.PORT),
         'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN || 'https://49af7fff247c445b9a7c98ee21ddfd2f@sentry.io/1427510'),
       })

--- a/package.json
+++ b/package.json
@@ -74,15 +74,15 @@
     "start-server-and-test": "^1.10.8"
   },
   "scripts": {
-    "dev": "NODE_ENV=development MEASUREMENTS_URL=http://api.ooni.io SENTRY_DSN=https://49af7fff247c445b9a7c98ee21ddfd2f@sentry.io/1427510 node index.js",
+    "dev": "NODE_ENV=development MEASUREMENTS_URL=https://ams-pg.ooni.org SENTRY_DSN=https://49af7fff247c445b9a7c98ee21ddfd2f@sentry.io/1427510 node index.js",
     "build-translations": "node ./scripts/build-translations.js",
     "extract-i18n-keys": "yarn build && node ./scripts/extract-react-intl-keys.js",
     "build": "next build",
     "export": "next export",
     "lint": "eslint --ignore-path .gitignore --ignore-pattern components/vendor .",
-    "test:e2e": "start-server-and-test dev http://localhost:3100 cypress:run",
+    "test:e2e": "yarn build && start-server-and-test start http://localhost:3100 cypress:run",
     "cypress:run": "cypress run",
     "test": "echo nothing interesting",
-    "start": "node index.js"
+    "start": "MEASUREMENTS_URL=https://ams-pg.ooni.org node index.js"
   }
 }

--- a/pages/measurement.js
+++ b/pages/measurement.js
@@ -38,12 +38,14 @@ export async function getServerSideProps({ query }) {
     params['input'] = query.input
   }
 
-  let msmtResult = await client.get('/api/v1/measurement_meta', {
+  let response = await client.get('/api/v1/measurement_meta', {
     params
   })
 
-  if (msmtResult?.data) {
-    initialProps = Object.assign({}, msmtResult.data)
+  // If response `data` is an empty object, the measurement was
+  // probably not found
+  if (response.hasOwnProperty('data') && Object.keys(response.data).length !== 0) {
+    initialProps = Object.assign({}, response.data)
 
     if (typeof initialProps['scores'] === 'string') {
       try {
@@ -54,7 +56,7 @@ export async function getServerSideProps({ query }) {
       }
     }
 
-    const { probe_cc } = msmtResult.data
+    const { probe_cc } = response.data
     const countryObj = countryUtil.countryList.find(country => (
       country.iso3166_alpha2 === probe_cc
     ))

--- a/pages/measurement.js
+++ b/pages/measurement.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import Head from 'next/head'
 import countryUtil from 'country-util'
@@ -15,6 +15,7 @@ import MeasurementNotFound from '../components/measurement/MeasurementNotFound'
 
 import Layout from '../components/Layout'
 import NavBar from '../components/NavBar'
+import mockApiResponse from '../static/mock-measurement.json'
 
 const pageColors = {
   default: theme.colors.base,
@@ -42,38 +43,12 @@ export async function getServerSideProps({ query }) {
 
   msmtResult = { data: {}}
 
-  msmtResult.data = {
-    anomaly: false,
-    confirmed: false,
-    failure: false,
-    input: 'inp',
-    measurement_start_time: '2020-02-09T23:57:26Z',
-    probe_asn: 22773,
-    probe_cc: 'US',
-    report_id: 'rid',
-    scores: '{"blocking_general":0.0,"blocking_global":0.0,"blocking_country":0.0,"blocking_isp":0.0,"blocking_local":0.0}',
-    test_name: 'web_connectivity',
-    test_start_time: '2020-02-09T23:56:06Z',
-    category_code: 'CULTR',
-  }
+  // XXX: Delete this
+  msmtResult.data = mockApiResponse
 
 
   if (msmtResult?.data) {
     initialProps = Object.assign({}, msmtResult.data)
-    const {
-      // anomaly,
-      // confirmed,
-      // failure,
-      // input,
-      // measurement_start_time,
-      // probe_asn,
-      probe_cc,
-      // report_id,
-      // scores,
-      // test_name,
-      // test_start_time,
-      // category_code
-    } = msmtResult.data
 
     if (typeof initialProps['scores'] === 'string') {
       try {
@@ -83,6 +58,7 @@ export async function getServerSideProps({ query }) {
       }
     }
 
+    const { probe_cc } = msmtResult.data
     const countryObj = countryUtil.countryList.find(country => (
       country.iso3166_alpha2 === probe_cc
     ))
@@ -98,21 +74,6 @@ export async function getServerSideProps({ query }) {
   }
 }
 
-const mock = {
-  test_runtime: 10,
-  test_keys: {
-    accessible: true,
-    blocking: 'http-diff',
-    queries: [],
-    tcp_connect: [],
-    requests: [],
-    client_resolver: null,
-    http_experiment_failure: false,
-    dns_experiment_failure: false,
-    control_failure: false
-  }
-}
-
 const Measurement = ({
   country,
   confirmed,
@@ -124,17 +85,9 @@ const Measurement = ({
   probe_asn,
   notFound = false,
   input,
+  measurement,
   ...rest
 }) => {
-  const [measurement, setMeasurement] = useState(null)
-
-  // Fetch full measurement here `&full=1`
-  useEffect(() => {
-    setTimeout(() => {
-      setMeasurement(mock)
-    }, 1000)
-  }, [])
-
   return (
     <Layout>
       <Head>
@@ -194,10 +147,10 @@ const Measurement = ({
                   />
                 }
                 {details}
-                {/* <CommonDetails
+                <CommonDetails
                   measurementURL={''}
                   measurement={measurement}
-                /> */}
+                />
               </Container>
             </React.Fragment>
           )} />

--- a/pages/measurement.js
+++ b/pages/measurement.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Head from 'next/head'
 import countryUtil from 'country-util'
@@ -11,6 +11,7 @@ import DetailsHeader from '../components/measurement/DetailsHeader'
 import SummaryText from '../components/measurement/SummaryText'
 import CommonDetails from '../components/measurement/CommonDetails'
 import MeasurementContainer from '../components/measurement/MeasurementContainer'
+import MeasurementNotFound from '../components/measurement/MeasurementNotFound'
 
 import Layout from '../components/Layout'
 import NavBar from '../components/NavBar'
@@ -26,6 +27,7 @@ const pageColors = {
 
 export async function getServerSideProps({ query }) {
   let initialProps = {}
+
   let client = axios.create({baseURL: process.env.MEASUREMENTS_URL}) // eslint-disable-line
   let params = {
     report_id: query.report_id
@@ -33,107 +35,179 @@ export async function getServerSideProps({ query }) {
   if (query.input) {
     params['input'] = query.input
   }
-  let msmtResult = await client.get('/api/v1/measurements', {
-    params
-  })
-  if (msmtResult.data.results.length > 0) {
-    const results = msmtResult.data.results
-    const measurementURL = results[0].measurement_url
-    if (results.length > 1) {
-      initialProps['warning'] = 'dupes'
+  let msmtResult = {}
+  // let msmtResult = await client.get('/api/v1/measurement_meta', {
+  //   params
+  // }).catch(e => { })
+
+  msmtResult = { data: {}}
+
+  msmtResult.data = {
+    anomaly: false,
+    confirmed: false,
+    failure: false,
+    input: 'inp',
+    measurement_start_time: '2020-02-09T23:57:26Z',
+    probe_asn: 22773,
+    probe_cc: 'US',
+    report_id: 'rid',
+    scores: '{"blocking_general":0.0,"blocking_global":0.0,"blocking_country":0.0,"blocking_isp":0.0,"blocking_local":0.0}',
+    test_name: 'web_connectivity',
+    test_start_time: '2020-02-09T23:56:06Z',
+    category_code: 'CULTR',
+  }
+
+
+  if (msmtResult?.data) {
+    initialProps = Object.assign({}, msmtResult.data)
+    const {
+      // anomaly,
+      // confirmed,
+      // failure,
+      // input,
+      // measurement_start_time,
+      // probe_asn,
+      probe_cc,
+      // report_id,
+      // scores,
+      // test_name,
+      // test_start_time,
+      // category_code
+    } = msmtResult.data
+
+    if (typeof initialProps['scores'] === 'string') {
+      try {
+        initialProps['scores'] = JSON.parse(initialProps['scores'])
+      } catch (e) {
+        console.error(`Failed to parse JSON in scores: ${e.toString()}`)
+      }
     }
-    let msmtContent = await client.get(measurementURL)
-    initialProps['measurement'] = msmtContent.data
-    initialProps['measurementURL'] = measurementURL
-    initialProps['isAnomaly'] = results[0].anomaly
-    initialProps['isFailure'] = results[0].failure
-    initialProps['isConfirmed'] = results[0].confirmed
-    initialProps['scores'] = results[0].scores || null
+
     const countryObj = countryUtil.countryList.find(country => (
-      country.iso3166_alpha2 === msmtContent.data.probe_cc
+      country.iso3166_alpha2 === probe_cc
     ))
 
-    initialProps['country'] = countryObj ? countryObj.name : 'Unknown'
+    initialProps['country'] = countryObj?.name || 'Unknown'
+  } else {
+    // Measurement not found
+    initialProps.notFound = true
   }
+
   return {
     props: initialProps
   }
 }
 
+const mock = {
+  test_runtime: 10,
+  test_keys: {
+    accessible: true,
+    blocking: 'http-diff',
+    queries: [],
+    tcp_connect: [],
+    requests: [],
+    client_resolver: null,
+    http_experiment_failure: false,
+    dns_experiment_failure: false,
+    control_failure: false
+  }
+}
 
 const Measurement = ({
-  measurement,
-  scores,
   country,
-  measurementURL,
-  isConfirmed,
-  isAnomaly,
-  isFailure
+  confirmed,
+  anomaly,
+  failure,
+  test_name,
+  test_start_time,
+  probe_cc,
+  probe_asn,
+  notFound = false,
+  input,
+  ...rest
 }) => {
+  const [measurement, setMeasurement] = useState(null)
+
+  // Fetch full measurement here `&full=1`
+  useEffect(() => {
+    setTimeout(() => {
+      setMeasurement(mock)
+    }, 1000)
+  }, [])
 
   return (
     <Layout>
       <Head>
         <title>OONI Explorer</title>
       </Head>
-      <MeasurementContainer
-        isConfirmed={isConfirmed}
-        isAnomaly={isAnomaly}
-        isFailure={isFailure}
-        country={country}
-        measurement={measurement}
-        scores={scores}
-        render={({
-          status = 'default',
-          statusIcon,
-          statusLabel,
-          statusInfo,
-          legacy = false,
-          summaryText,
-          details }) => (
+      {notFound ? (
+        <MeasurementNotFound />
+      ): (
+        <MeasurementContainer
+          isConfirmed={confirmed}
+          isAnomaly={anomaly}
+          isFailure={failure}
+          testName={test_name}
+          measurement={measurement}
+          {...rest}
 
-          <React.Fragment>
-            <NavBar color={pageColors[status]} />
-            <Hero
-              color={pageColors[status]}
-              status={status}
-              icon={statusIcon}
-              label={statusLabel}
-              info={statusInfo}
-            />
-            <CommonSummary
-              color={pageColors[status]}
-              measurement={measurement}
-              country={country} />
-
-            <Container>
-              <DetailsHeader
-                testName={measurement.test_name}
-                runtime={measurement.test_runtime}
-                notice={legacy}
+          render={({
+            status = 'default',
+            statusIcon,
+            statusLabel,
+            statusInfo,
+            legacy = false,
+            summaryText,
+            details
+          }) => (
+            <React.Fragment>
+              <NavBar color={pageColors[status]} />
+              <Hero
+                color={pageColors[status]}
+                status={status}
+                icon={statusIcon}
+                label={statusLabel}
+                info={statusInfo}
+              />
+              <CommonSummary
+                test_start_time={test_start_time}
+                probe_asn={probe_asn}
+                probe_cc={probe_cc}
+                color={pageColors[status]}
+                country={country}
               />
 
-              {summaryText && <SummaryText
-                testName={measurement.test_name}
-                testUrl={measurement.input}
-                network={measurement.probe_asn}
-                country={country}
-                date={measurement.test_start_time}
-                content={summaryText}
-              />}
-              {details}
-              <CommonDetails
-                measurementURL={measurementURL}
-                measurement={measurement} />
-            </Container>
-          </React.Fragment>
-        )} />
+              <Container>
+                <DetailsHeader
+                  testName={test_name}
+                  runtime={measurement?.test_runtime}
+                  notice={legacy}
+                />
+                {summaryText &&
+                  <SummaryText
+                    testName={test_name}
+                    testUrl={input}
+                    network={probe_asn}
+                    country={country}
+                    date={test_start_time}
+                    content={summaryText}
+                  />
+                }
+                {details}
+                {/* <CommonDetails
+                  measurementURL={''}
+                  measurement={measurement}
+                /> */}
+              </Container>
+            </React.Fragment>
+          )} />
+      )}
     </Layout>
   )
 }
 
 Measurement.propTypes = {
-  measurement: PropTypes.object.isRequired,
+  measurement: PropTypes.object,
   measurementURL: PropTypes.string,
   isAnomaly: PropTypes.bool,
   isFailure: PropTypes.bool,

--- a/static/mock-measurement.json
+++ b/static/mock-measurement.json
@@ -1,0 +1,234 @@
+{
+  "anomaly": false,
+  "confirmed": false,
+  "failure": false,
+  "input": "inp",
+  "measurement_start_time": "2020-02-09T23:57:26Z",
+  "probe_asn": 22773,
+  "probe_cc": "US",
+  "report_id": "rid",
+  "scores": "{'blocking_general':0.0,'blocking_global':0.0,'blocking_country':0.0,'blocking_isp':0.0,'blocking_local':0.0}",
+  "test_name": "web_connectivity",
+  "test_start_time": "2020-02-09T23:56:06Z",
+  "category_code": "CULTR",
+  "measurement": {
+    "test_keys": {
+      "accessible": true,
+      "control": {
+        "tcp_connect": {
+          "104.28.25.130:80": {
+            "status": true,
+            "failure": null
+          },
+          "104.28.24.130:80": {
+            "status": true,
+            "failure": null
+          }
+        },
+        "http_request": {
+          "body_length": 92179,
+          "failure": null,
+          "status_code": 200,
+          "headers": {
+            "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+            "Via": "1.1 varnish-v4",
+            "Set-Cookie": "__cfduid=dc6c0f5a62955ff34c47ab63ba5b6d9921588998412; expires=Mon, 08-Jun-20 04:26:52 GMT; path=/; domain=.ledarsidorna.se; HttpOnly; SameSite=Lax",
+            "Age": "104",
+            "Vary": "Accept-Encoding",
+            "cf-request-id": "029948b22c0000c7619c015200000001",
+            "Server": "cloudflare",
+            "X-Varnish": "1166306 8383239",
+            "Link": "<https://ledarsidorna.se/wp-json/>; rel=\"https://api.w.org/\"",
+            "Date": "Sat, 09 May 2020 04:26:52 GMT",
+            "CF-RAY": "5908aa304ad7c761-AMS",
+            "Content-Type": "text/html; charset=UTF-8",
+            "CF-Cache-Status": "DYNAMIC"
+          },
+          "title": "\n\t\tLedarsidorna.se - Alltid i opposition\t"
+        },
+        "dns": {
+          "failure": null,
+          "addrs": [
+            "104.28.24.130",
+            "104.28.25.130"
+          ]
+        }
+      },
+      "control_failure": null,
+      "socksproxy": null,
+      "http_experiment_failure": null,
+      "agent": "redirect",
+      "retries": null,
+      "client_resolver": "127.0.0.1",
+      "dns_consistency": "consistent",
+      "dns_experiment_failure": null,
+      "body_proportion": 1,
+      "blocking": false,
+      "queries": [
+        {
+          "engine": "system",
+          "resolver_hostname": null,
+          "query_type": "A",
+          "hostname": "ledarsidorna.se",
+          "answers": [
+            {
+              "hostname": "ledarsidorna.se",
+              "answer_type": "CNAME",
+              "ttl": null
+            },
+            {
+              "ipv4": "104.28.25.130",
+              "answer_type": "A",
+              "ttl": null
+            },
+            {
+              "ipv4": "104.28.24.130",
+              "answer_type": "A",
+              "ttl": null
+            }
+          ],
+          "failure": null,
+          "resolver_port": null
+        }
+      ],
+      "body_length_match": true,
+      "requests": [
+        {
+          "failure": null,
+          "request": {
+            "body": "",
+            "headers": {
+              "Accept-Language": "en-US;q=0.8,en;q=0.5",
+              "Cookie": "__cfduid=d403c81d7f488357c6347c42e2776d640158899841",
+              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+              "User-Agent": "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            "tor": {
+              "is_tor": false,
+              "exit_ip": null,
+              "exit_name": null
+            },
+            "url": "https://ledarsidorna.se/",
+            "method": "GET"
+          },
+          "response": {
+            "body": "[redacted body here]",
+            "headers": {
+              "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+              "Via": "1.1 varnish-v4",
+              "Transfer-Encoding": "chunked",
+              "Age": "104",
+              "Vary": "Accept-Encoding",
+              "cf-request-id": "029948af7c0000d8794e90a200000001",
+              "Server": "cloudflare",
+              "Connection": "keep-alive",
+              "X-Varnish": "1166302 8383239",
+              "Link": "<https://ledarsidorna.se/wp-json/>; rel=\"https://api.w.org/\"",
+              "Date": "Sat, 09 May 2020 04:26:52 GMT",
+              "CF-RAY": "5908aa2bf809d879-CPH",
+              "Content-Type": "text/html; charset=UTF-8",
+              "CF-Cache-Status": "DYNAMIC"
+            },
+            "response_line": "HTTP/1.1 200 OK",
+            "code": 200
+          }
+        },
+        {
+          "failure": null,
+          "request": {
+            "body": "",
+            "headers": {
+              "Accept-Language": "en-US;q=0.8,en;q=0.5",
+              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+              "User-Agent": "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            "tor": {
+              "is_tor": false,
+              "exit_ip": null,
+              "exit_name": null
+            },
+            "url": "http://ledarsidorna.se/",
+            "method": "GET"
+          },
+          "response": {
+            "body": "",
+            "headers": {
+              "Via": "1.1 varnish-v4",
+              "Transfer-Encoding": "chunked",
+              "Set-Cookie": "__cfduid=d403c81d7f488357c6347c42e2776d6401588998411; expires=Mon, 08-Jun-20 04:26:51 GMT; path=/; domain=.ledarsidorna.se; HttpOnly; SameSite=Lax",
+              "Age": "0",
+              "cf-request-id": "029948ae850000d89193015200000001",
+              "Server": "cloudflare",
+              "Connection": "keep-alive",
+              "X-Varnish": "10242248",
+              "Location": "https://ledarsidorna.se/",
+              "Date": "Sat, 09 May 2020 04:26:51 GMT",
+              "CF-RAY": "5908aa2a6fa0d891-CPH",
+              "Content-Type": "text/html; charset=UTF-8",
+              "CF-Cache-Status": "DYNAMIC"
+            },
+            "response_line": "HTTP/1.1 302 Found",
+            "code": 302
+          }
+        }
+      ],
+      "tcp_connect": [
+        {
+          "status": {
+            "failure": null,
+            "success": true,
+            "blocked": false
+          },
+          "ip": "104.28.25.130",
+          "port": 80
+        },
+        {
+          "status": {
+            "failure": null,
+            "success": true,
+            "blocked": false
+          },
+          "ip": "104.28.24.130",
+          "port": 80
+        }
+      ],
+      "title_match": true,
+      "headers_match": true,
+      "status_code_match": true
+    },
+    "test_start_time": "2020-05-09 04:32:54",
+    "input_hashes": [],
+    "probe_ip": "127.0.0.1",
+    "probe_city": null,
+    "test_helpers": {
+      "backend": {
+        "type": "https",
+        "address": "https://wcth.ooni.io"
+      }
+    },
+    "probe_cc": "SE",
+    "id": "d15df329-5242-4fb0-8a7b-4f8a86e739f4",
+    "test_runtime": 1.2498528957,
+    "input": "http://ledarsidorna.se",
+    "probe_asn": "AS1257",
+    "annotations": {
+      "engine_name": "libmeasurement_kit",
+      "engine_version_full": "v0.10.11",
+      "engine_version": "0.10.11",
+      "platform": "android",
+      "flavor": "full",
+      "network_type": "mobile"
+    },
+    "software_name": "ooniprobe-android",
+    "software_version": "2.3.2",
+    "data_format_version": "0.2.0",
+    "report_filename": "2020-05-09/20200509T043254Z-SE-AS1257-web_connectivity-20200509T042651Z_AS1257_ybb3RoTQ7VmPcnF3UfhgtyrlnGXkVSGsOCgwHjhZrSENuC5M9e-0.2.0-probe.json",
+    "test_version": "0.0.1",
+    "bucket_date": "2020-05-09",
+    "test_name": "web_connectivity",
+    "report_id": "20200509T042651Z_AS1257_ybb3RoTQ7VmPcnF3UfhgtyrlnGXkVSGsOCgwHjhZrSENuC5M9e",
+    "measurement_start_time": "2020-05-09 04:32:55",
+    "backend_version": null,
+    "options": []
+  }
+}


### PR DESCRIPTION
Fixes #489

Uses the new `/api/v1/measurement_meta` API to fetch measurement data.
- [X] ~Revert 8d0f1c7 before merging~ We decided to continue to use the `ams-pg.ooni.org` hostname for now.