### PR TITLE
Handle missing test keys

### DIFF
--- a/components/measurement/MeasurementContainer.js
+++ b/components/measurement/MeasurementContainer.js
@@ -39,7 +39,12 @@ const MeasurementContainer = ({ measurement, ...props }) => {
   }
 
   const TestDetails = mapTestDetails[measurement.test_name] || DefaultTestDetails
-  return <TestDetails measurement={measurement} {...props} />
+
+  return (
+    <React.Fragment>
+      <TestDetails measurement={measurement} {...props} />
+    </React.Fragment>
+  )
 }
 
 export default MeasurementContainer

--- a/components/measurement/PerformanceDetails.js
+++ b/components/measurement/PerformanceDetails.js
@@ -13,40 +13,37 @@ const PerformanceDetails = ({
   timeouts
 }) => {
   const intl = useIntl()
-  let items = [
-    {
-      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.AvgPing' }),
-      value: averagePing.toString() + ' ms'
-    },
-    {
-      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MaxPing' }),
-      value: `${isNdt7 ? '~' : ''}${maxPing.toString()} ms`
-    },
-    {
-      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MSS' }),
-      value: mss.toString()
-    },
-    {
-      label: isNdt7 ? intl.formatMessage({
-        id: 'Measurement.Details.Performance.Label.RetransmitRate',
-        defaultMessage: 'Retransmit Rate'
-      }): intl.formatMessage({ id: 'Measurement.Details.Performance.Label.PktLoss' }),
-      value: packetLoss.toString() + '%'
-    },
-  ]
+  let items = []
+  averagePing && items.push({
+    label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.AvgPing' }),
+    value: `${averagePing} ms`
+  })
+  maxPing && items.push({
+    label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MaxPing' }),
+    value: `${isNdt7 ? '~' : ''}${maxPing} ms`
+  })
+  mss && items.push({
+    label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.MSS' }),
+    value: `${mss}`
+  })
+
+  packetLoss != undefined && items.push({
+    label: isNdt7 ? intl.formatMessage({
+      id: 'Measurement.Details.Performance.Label.RetransmitRate'
+    }): intl.formatMessage({ id: 'Measurement.Details.Performance.Label.PktLoss' }),
+    value: `${packetLoss}%`
+  })
 
   //Only add outOfOrder and timeouts if NDT4/5 measurement
-  if(!isNdt7){
-    items = items.concat([
-      {
-        label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.OutOfOrder' }),
-        value: outOfOrder.toString() + '%'
-      },
-      {
-        label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.Timeouts' }),
-        value: timeouts.toString()
-      }
-    ])
+  if(!isNdt7) {
+    outOfOrder != undefined && items.push({
+      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.OutOfOrder' }),
+      value: outOfOrder.toString() + '%'
+    })
+    timeouts != undefined && items.push({
+      label: intl.formatMessage({ id: 'Measurement.Details.Performance.Label.Timeouts' }),
+      value: timeouts.toString()
+    })
   }
 
   return (

--- a/components/measurement/nettests/Dash.js
+++ b/components/measurement/nettests/Dash.js
@@ -1,24 +1,8 @@
-
 import React from 'react'
 import PropTypes from 'prop-types'
-import {
-  Heading,
-  Flex,
-  Box,
-  theme
-} from 'ooni-components'
-
+import { Flex, Box } from 'ooni-components'
 import { Text } from 'rebass'
 import { useIntl } from 'react-intl'
-
-import {
-  VictoryChart,
-  VictoryLine,
-  VictoryTooltip,
-  VictoryVoronoiContainer,
-  VictoryAxis
-} from 'victory'
-
 import MdFlashOn from 'react-icons/lib/md/flash-on'
 
 const InfoBoxItem = ({
@@ -92,10 +76,9 @@ const getOptimalQualityForBitrate = (testKeys) => {
 const DashDetails = ({ measurement, render }) => {
   const intl = useIntl()
   const testKeys = measurement.test_keys
-  // const isFailed = testKeys.failure !== null
-  // const failure = testKeys.failure
+  const failure = testKeys.failure
 
-  if (typeof testKeys.simple === 'undefined' || typeof testKeys.receiver_data === 'undefined') {
+  if (failure === true || typeof testKeys.simple === 'undefined' || typeof testKeys.receiver_data === 'undefined') {
     return render({
       status: 'error'
     })
@@ -104,13 +87,6 @@ const DashDetails = ({ measurement, render }) => {
   const optimalVideoRate = getOptimalQualityForBitrate(testKeys).type
   const medianBitrate = (testKeys.simple.median_bitrate / 1000).toFixed(2)
   const playoutDelay = (testKeys.simple.min_playout_delay).toFixed(2)
-
-  // construct data for graph
-  const clientData = testKeys.receiver_data
-  const data = clientData.map(iteration => ({
-    x: iteration.iteration,
-    y: iteration.rate / 1000,
-  }))
 
   return (
     render({
@@ -134,55 +110,7 @@ const DashDetails = ({ measurement, render }) => {
           </Flex>
         </Box>
       ),
-      details: (
-        <Flex>
-          {/*<Box p={3} width={1}>
-            <Heading h={4}> Video Quality by time </Heading>
-            <Box>
-              <VictoryChart
-                height={200}
-                width={600}
-                containerComponent={
-                  <VictoryVoronoiContainer voronoiDimension="x"
-                    labels={(d) => `${d.y} Mb/s`}
-                    labelComponent={<VictoryTooltip
-                      cornerRadius={0}
-                      flyoutStyle={{fill: 'WHITE'}}
-                    />}
-                  />
-                }
-              >
-                <VictoryAxis
-                  tickValues={data.map((i => i.x + 's'))}
-                  style={{
-                    tickLabels: { fontSize: 10, padding: 5}
-                  }}
-                />
-                <VictoryAxis
-                  dependentAxis
-                  style={{
-                    axisLabel: { fontSize: 10, padding: 0 },
-                    ticks: { stroke: "grey", size: 5 },
-                    tickLabels: { fontSize: 10, padding: 5 }
-                  }}
-                />
-                <VictoryLine
-                  style={{
-                    data: { stroke: theme.colors.base }
-                  }}
-                  data={data}
-                  animate={{
-                    duration: 2000,
-                    onLoad: { duration: 1000 }
-                  }}
-
-
-                />
-              </VictoryChart>
-            </Box>
-          </Box>*/}
-        </Flex>
-      )
+      details: null
     })
   )
 }

--- a/components/measurement/nettests/HTTPHeaderFieldManipulation.js
+++ b/components/measurement/nettests/HTTPHeaderFieldManipulation.js
@@ -9,7 +9,7 @@ export const HttpHeaderFieldManipulationDetails = ({ measurement, render }) => {
   const testKeys = measurement.test_keys
   let isAnomaly = false
   let isFailed = true
-  const tampering = testKeys.tampering
+  const tampering = testKeys?.tampering || {}
   Object.keys(tampering).forEach((key) => {
     if (tampering[key] === true) {
       isAnomaly = true
@@ -18,7 +18,7 @@ export const HttpHeaderFieldManipulationDetails = ({ measurement, render }) => {
       isFailed = false
     }
   })
-  const headerDiff = testKeys.tampering.header_name_diff
+  // const headerDiff = testKeys.tampering.header_name_diff
 
   return (
     render({
@@ -32,7 +32,7 @@ export const HttpHeaderFieldManipulationDetails = ({ measurement, render }) => {
       details: (
         <div>
           {/*<Text>isAnomaly: {isAnomaly.toString()}</Text>
-          <Text>isFailed: {isFailed.toString()}</Text>
+            <Text>isFailed: {isFailed.toString()}</Text>
           <Text>headerDiff: {headerDiff.toString()}</Text>*/}
         </div>
       )

--- a/components/measurement/nettests/HTTPHeaderFieldManipulation.js
+++ b/components/measurement/nettests/HTTPHeaderFieldManipulation.js
@@ -18,7 +18,6 @@ export const HttpHeaderFieldManipulationDetails = ({ measurement, render }) => {
       isFailed = false
     }
   })
-  // const headerDiff = testKeys.tampering.header_name_diff
 
   return (
     render({
@@ -29,13 +28,6 @@ export const HttpHeaderFieldManipulationDetails = ({ measurement, render }) => {
       summaryText: isAnomaly
         ? 'Measurement.HTTPHeaderManipulation.MiddleBoxesDetected.SummaryText'
         : 'Measurement.HTTPHeaderManipulation.NoMiddleBoxes.SummaryText',
-      details: (
-        <div>
-          {/*<Text>isAnomaly: {isAnomaly.toString()}</Text>
-            <Text>isFailed: {isFailed.toString()}</Text>
-          <Text>headerDiff: {headerDiff.toString()}</Text>*/}
-        </div>
-      )
     })
   )
 }

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -150,6 +150,9 @@ const RequestResponseContainer = ({request}) => {
 }
 
 const FailureString = ({failure}) => {
+  if (typeof failure === 'undefined') {
+    return (<FormattedMessage id='Measurement.Details.Endpoint.Status.Unknown' />)
+  }
   if (!failure) {
     return (
       <div>

--- a/components/measurement/useTestKeyController.js
+++ b/components/measurement/useTestKeyController.js
@@ -1,8 +1,6 @@
-import React, { useState, useCallback } from 'react'
-import { Flex } from 'ooni-components'
-
-// Custom hook to render a toolbar to enable/disable parts of `testKeys`
-// Usage: Add this to the MeasurementContainer
+// This file contains a custom hook to render a toolbar
+// that can be used to enable/disable parts of `testKeys`
+// To use it, add the below code in components/measurement/MeasurementContainer.js
 /*
 import { useTestKeyController } from './useTestKeyController'
 ...
@@ -18,7 +16,12 @@ return (
 )
 */
 
+import React, { useState, useCallback } from 'react'
+import { Flex } from 'ooni-components'
+
+
 const setValues = (input, value = true) => {
+  // Maps each key in `test_keys` to a boolean value, by default true
   return Object.keys(input).reduce((o, k) => {
     o[k] = value
     return o
@@ -36,23 +39,21 @@ export const useTestKeyController = (testKeysInitial) => {
       if (name === 'all') {
         setTestKeys(checked ? testKeysInitial : {})
         setKeysMap(setValues(testKeysInitial, checked))
-        return
       } else {
         const newTestKeys = {...testKeys}
-
+        // add or delete the original entry from `test_keys`
         if (checked) {
           newTestKeys[name] = testKeysInitial[name]
         } else {
           delete newTestKeys[name]
         }
         setTestKeys(newTestKeys)
+        setKeysMap(keysMap => {
+          const newKeysMap = {...keysMap}
+          newKeysMap[name] = checked
+          return newKeysMap
+        })
       }
-
-      setKeysMap(keysMap => {
-        const newKeysMap = {...keysMap}
-        newKeysMap[name] = checked
-        return newKeysMap
-      })
     }, [keysMap, testKeys, setKeysMap, setTestKeys])
 
     return (

--- a/components/measurement/useTestKeyController.js
+++ b/components/measurement/useTestKeyController.js
@@ -1,0 +1,71 @@
+import React, { useState, useCallback } from 'react'
+import { Flex } from 'ooni-components'
+
+// Custom hook to render a toolbar to enable/disable parts of `testKeys`
+// Usage: Add this to the MeasurementContainer
+/*
+import { useTestKeyController } from './useTestKeyController'
+...
+...
+const { testKeys, TestKeyController } = useTestKeyController(measurement.test_keys)
+const measurementMod = Object.assign({}, measurement, { test_keys: testKeys })
+
+return (
+  <React.Fragment>
+    <TestKeyController />
+    <TestDetails measurement={measurementMod} {...props} />
+  </React.Fragment>
+)
+*/
+
+const setValues = (input, value = true) => {
+  return Object.keys(input).reduce((o, k) => {
+    o[k] = value
+    return o
+  }, {all: value})
+}
+
+export const useTestKeyController = (testKeysInitial) => {
+  const [testKeys, setTestKeys] = useState(testKeysInitial)
+  const [keysMap, setKeysMap] = useState(setValues(testKeysInitial))
+
+  const TestKeyController = () => {
+    const onChange = useCallback((event) => {
+      const {name, checked} = event.target
+
+      if (name === 'all') {
+        setTestKeys(checked ? testKeysInitial : {})
+        setKeysMap(setValues(testKeysInitial, checked))
+        return
+      } else {
+        const newTestKeys = {...testKeys}
+
+        if (checked) {
+          newTestKeys[name] = testKeysInitial[name]
+        } else {
+          delete newTestKeys[name]
+        }
+        setTestKeys(newTestKeys)
+      }
+
+      setKeysMap(keysMap => {
+        const newKeysMap = {...keysMap}
+        newKeysMap[name] = checked
+        return newKeysMap
+      })
+    }, [keysMap, testKeys, setKeysMap, setTestKeys])
+
+    return (
+      <Flex flexWrap='wrap' justifyContent='space-evenly'>
+        {Object.keys(keysMap).map((k, i) =>
+          <Flex key={i} mr={2} alignItems='center'>
+            <input type='checkbox' name={k} checked={keysMap[k]} onChange={onChange} />
+            <label htmlFor={k}>{k}</label>
+          </Flex>
+        )}
+      </Flex>
+    )
+  }
+
+  return { testKeys, TestKeyController }
+}


### PR DESCRIPTION
Fixes #416 

Makes sure all measurement pages render without crashing when any of the keys  in `test_keys`are not found in the measurement.

Also includes a development toolbar (not added to any pages) that allows us to control the values inside different `test_keys`
![image](https://user-images.githubusercontent.com/700829/93643255-a7613900-f9cd-11ea-930c-6a2e982f266d.png)
