### PR TITLE
Make it harder to find AS0 measurements

### DIFF
--- a/components/measurement/MeasurementContainer.js
+++ b/components/measurement/MeasurementContainer.js
@@ -15,6 +15,7 @@ import PsiphonDetails from './nettests/Psiphon'
 import TorDetails from './nettests/Tor'
 
 import DefaultTestDetails from './nettests/Default'
+import MeasurementNotFound from './MeasurementNotFound'
 
 const mapTestDetails = {
   web_connectivity: WebConnectivityDetails,
@@ -29,9 +30,6 @@ const mapTestDetails = {
   psiphon: PsiphonDetails,
   tor: TorDetails
 }
-
-// FIXME to have header and stuff
-const MeasurementNotFound = () => <h4>Measurement not Found</h4>
 
 const MeasurementContainer = ({ measurement, ...props }) => {
   if (measurement === undefined) {

--- a/components/measurement/MeasurementNotFound.js
+++ b/components/measurement/MeasurementNotFound.js
@@ -3,8 +3,13 @@ import React from 'react'
 import NavBar from '../NavBar'
 import { Container, Flex, Box, Heading, Text } from 'ooni-components'
 import { useRouter } from 'next/router'
+import styled from 'styled-components'
 
 import OONI404 from '../../static/images/OONI_404.svg'
+
+const WordBreakText = styled(Text)`
+  word-wrap: break-word;
+`
 
 const MeasurementNotFound = () => {
   const { asPath } = useRouter()
@@ -12,13 +17,13 @@ const MeasurementNotFound = () => {
     <React.Fragment>
       <NavBar />
       <Container>
-        <Flex justifyContent='space-around' alignItems='center' my={5}>
+        <Flex flexDirection={['column', 'row']} justifyContent='space-around' alignItems='center' my={5}>
           <OONI404 height='200px' />
-          <Box width={1/2}>
+          <Box width={[1, 1/2]} my={[3, 0]}>
             <Heading color='blue5' h={4}>Measurement Not Found</Heading>
-            <Text color='gray8'>
+            <WordBreakText color='gray8' as='code'>
               {`${process.env.EXPLORER_URL}${asPath}`}
-            </Text>
+            </WordBreakText>
           </Box>
         </Flex>
       </Container>

--- a/components/measurement/MeasurementNotFound.js
+++ b/components/measurement/MeasurementNotFound.js
@@ -1,0 +1,29 @@
+/* global process */
+import React from 'react'
+import NavBar from '../NavBar'
+import { Container, Flex, Box, Heading, Text } from 'ooni-components'
+import { useRouter } from 'next/router'
+
+import OONI404 from '../../static/images/OONI_404.svg'
+
+const MeasurementNotFound = () => {
+  const { asPath } = useRouter()
+  return (
+    <React.Fragment>
+      <NavBar />
+      <Container>
+        <Flex justifyContent='space-around' alignItems='center' my={5}>
+          <OONI404 height='200px' />
+          <Box width={1/2}>
+            <Heading color='blue5' h={4}>Measurement Not Found</Heading>
+            <Text color='gray8'>
+              {`${process.env.EXPLORER_URL}${asPath}`}
+            </Text>
+          </Box>
+        </Flex>
+      </Container>
+    </React.Fragment>
+  )
+}
+
+export default MeasurementNotFound

--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -118,8 +118,14 @@ class FilterSidebar extends React.Component {
       switch(filterName) {
       case 'asnFilter':
         var asnValue = e.target.value
-        var asnRegEx = /^(^AS|as)?[0-9]+$/
-        if (asnValue && asnValue.match(asnRegEx) === null) {
+        // Accepts only formats like AS1234 or 1234
+        // https://regex101.com/r/DnkspD/latest
+        var asnRegEx = /^(AS)?([1-9][0-9]*)$/
+        if (
+          typeof asnValue === 'string' &&
+          asnValue !== '' &&
+          asnValue.match(asnRegEx) === null
+        ) {
           this.setState({
             asnError: intl.formatMessage({id: 'Search.Sidebar.ASN.Error'}),
             isFilterDirty: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-explorer",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "license": "BSD-3-Clause",
   "main": "index.js",

--- a/pages/measurement.js
+++ b/pages/measurement.js
@@ -28,6 +28,11 @@ export default class Measurement extends React.Component {
 
   static async getInitialProps ({ query }) {
     let initialProps = {}
+
+    if (query.report_id.includes('AS0')) {
+      return initialProps
+    }
+
     let client = axios.create({baseURL: process.env.MEASUREMENTS_URL}) // eslint-disable-line
     let params = {
       report_id: query.report_id

--- a/pages/search.js
+++ b/pages/search.js
@@ -179,10 +179,12 @@ class Search extends React.Component {
     }
 
     const measurements = msmtR.data
+    // drop results with probe_asn === 'AS0'
+    const results = measurements.results.filter(item => item.probe_asn !== 'AS0')
 
     return {
       error: null,
-      results: measurements.results,
+      results,
       nextURL: measurements.metadata.next_url,
       testNamesKeyed,
       testNames,
@@ -240,8 +242,9 @@ class Search extends React.Component {
     axios.get(this.state.nextURL)
       .then((res) => {
         // XXX update the query
+        const nextPageResults = res.data.results.filter(item => item.probe_asn !== 'AS0')
         this.setState({
-          results: this.state.results.concat(res.data.results),
+          results: this.state.results.concat(nextPageResults),
           nextURL: res.data.metadata.next_url,
           show: this.state.show + 50
         })
@@ -268,9 +271,10 @@ class Search extends React.Component {
         // XXX do error handling
         getMeasurements(query)
           .then((res) => {
+            const results = res.data.results.filter(item => item.probe_asn !== 'AS0')
             this.setState({
               loading: false,
-              results: res.data.results,
+              results,
               nextURL: res.data.metadata.next_url
             })
           })


### PR DESCRIPTION
Related to #495 

- Consider `AS0` and `0` as invalid inputs for the `probe_asn` field in search queries
- Omit search result items with `probe_asn: "AS0"` in them
- Do not generate pages for measurements which have `AS0` in the report id (part of the URL)
- Bump version to `2.0.10`