### PR TITLE
Set default since date in search to 30 days from until date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.1.1] - 2020-10-27
+
+### Changed
+* Date filters in search will default to a 30 day range unless manually changed.
+  This is to align with the new default in the `/api/v1/measurements` API. (#512)
+
+### Fixed
+* Fix DNS Queries box by handling AAAA answer types correctly (#505)
+
 ## [2.1.0] - 2020-10-15
 
 ### Changed
@@ -157,6 +166,7 @@ instead of domain name filter. Avoids timeouts when API is slow.
 ### Added
 - First public release ([Blog post](https://ooni.org/post/next-generation-ooni-explorer/))
 
+[2.1.1]: https://github.com/ooni/explorer/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/ooni/explorer/compare/v2.0.10...v2.1.0
 [2.0.10]: https://github.com/ooni/explorer/compare/v2.0.9...v2.0.10
 [2.0.9]: https://github.com/ooni/explorer/compare/v2.0.8...v2.0.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-explorer",
-  "version": "2.1.1-dev",
+  "version": "2.1.1",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "license": "BSD-3-Clause",
   "main": "index.js",

--- a/pages/search.js
+++ b/pages/search.js
@@ -144,6 +144,11 @@ class Search extends React.Component {
       query.until = until
     }
 
+    const since = moment(query.until).utc().subtract(30, 'day').format('YYYY-MM-DD')
+    if (!query.since) {
+      query.since = since
+    }
+
     [testNamesR, countriesR] = await Promise.all([
       client.get('/api/_/test_names'),
       client.get('/api/_/countries')


### PR DESCRIPTION
Fixes #507 

* Going directly to `/search` sets the since date to `${today} - 30`
* If there is already an `until` date in the page URL, since date is set to `${until} - 30`

![image](https://user-images.githubusercontent.com/700829/97259890-32fe8e80-17f2-11eb-9d1e-6a3cfce771a4.png)
