### PR TITLE
Handle missing array values in test_keys

### DIFF
--- a/components/measurement/nettests/FacebookMessenger.js
+++ b/components/measurement/nettests/FacebookMessenger.js
@@ -88,7 +88,7 @@ export const FacebookMessengerDetails = ({ measurement, render }) => {
                       />
                     </Box>
                   </Flex>
-                  {tcpConnections && tcpConnections.length > 0 &&
+                  {Array.isArray(tcpConnections) && tcpConnections.length > 0 &&
                   <React.Fragment>
                     <Heading h={4}> <FormattedMessage id='Measurement.Details.FacebookMessenger.Endpoint.Status.Heading' /> </Heading>
                     {tcpConnections.map((connection, index) => (

--- a/components/measurement/nettests/Telegram.js
+++ b/components/measurement/nettests/Telegram.js
@@ -93,7 +93,7 @@ const TelegramDetails = ({ measurement, render }) => {
                       />
                     </Box>
                   </Flex>
-                  {tcp_connect && tcp_connect.length > 0 &&
+                  {Array.isArray(tcp_connect) && tcp_connect.length > 0 &&
                   <div>
                     <Heading h={4}> <FormattedMessage id='Measurement.Details.Telegram.Endpoint.Status.Heading' /> </Heading>
                     {tcp_connect.map((connection, index) => (

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -219,7 +219,7 @@ const QueryContainer = ({query}) => {
     failure
   } = query
   return (
-    <Flex flexWrap='wrap'>
+    <Flex flexWrap='wrap' my={2}>
       <Box width={1} mb={2}>
         {/* Metadata */}
         <Flex>
@@ -240,26 +240,28 @@ const QueryContainer = ({query}) => {
         </Flex>
       </Box>
       {failure && <Box width={1}><FailureString failure={failure} /></Box>}
-      <Box width={1}>
-        <FiveColRow header />
-        {answers.map((dnsAnswer, index) => (
-          <FiveColRow
-            key={index}
-            name='@'
-            netClass='IN'
-            ttl={dnsAnswer.ttl}
-            type={dnsAnswer.answer_type}
-            data={dnsAnswer.answer_type === 'A'
-              ? dnsAnswer.ipv4
-              : dnsAnswer.answer_type === 'AAAA'
-                ? dnsAnswer.ipv6
-                : dnsAnswer.answer_type === 'CNAME'
-                  ? dnsAnswer.hostname
-                  : null // for any other answer_type, DATA column will be empty
-            }
-          />
-        ))}
-      </Box>
+      {!failure &&
+        <Box width={1}>
+          <FiveColRow header />
+          {Array.isArray(answers) && answers.map((dnsAnswer, index) => (
+            <FiveColRow
+              key={index}
+              name='@'
+              netClass='IN'
+              ttl={dnsAnswer.ttl}
+              type={dnsAnswer.answer_type}
+              data={dnsAnswer.answer_type === 'A'
+                ? dnsAnswer.ipv4
+                : dnsAnswer.answer_type === 'AAAA'
+                  ? dnsAnswer.ipv6
+                  : dnsAnswer.answer_type === 'CNAME'
+                    ? dnsAnswer.hostname
+                    : null // for any other answer_type, DATA column will be empty
+              }
+            />
+          ))}
+        </Box>
+      }
     </Flex>
 
   )
@@ -285,7 +287,7 @@ const WebConnectivityDetails = ({
       accessible,
       blocking,
       queries,
-      tcp_connect = [],
+      tcp_connect,
       requests,
       client_resolver,
       http_experiment_failure,
@@ -452,14 +454,14 @@ const WebConnectivityDetails = ({
     )
   }
 
-  const tcpConnections = tcp_connect.map((connection) => {
+  const tcpConnections = Array.isArray(tcp_connect) ? tcp_connect.map((connection) => {
     const status = (connection.status.success) ? 'Success' :
       (connection.status.blocked) ? 'Blocked' : 'Failed'
     return {
       destination: connection.ip + ':' + connection.port,
       status
     }
-  })
+  }) : []
 
   return (
     <React.Fragment>
@@ -513,7 +515,7 @@ const WebConnectivityDetails = ({
                       </Box>
                     </Flex>
                     <Box width={1}>
-                      {queries && queries.map((query, index) => <QueryContainer key={index} query={query} />)}
+                      {Array.isArray(queries) && queries.map((query, index) => <QueryContainer key={index} query={query} />)}
                     </Box>
                   </React.Fragment>
                 }
@@ -551,7 +553,7 @@ const WebConnectivityDetails = ({
               <DetailsBox
                 title={<FormattedMessage id='Measurement.Details.Websites.HTTP.Heading' />}
                 content={
-                  requests ? (
+                  Array.isArray(requests) ? (
                     <Box width={1}>
                       {requests.map((request, index) => <RequestResponseContainer key={index} request={request} />)}
                     </Box>

--- a/components/measurement/nettests/WhatsApp.js
+++ b/components/measurement/nettests/WhatsApp.js
@@ -100,7 +100,7 @@ const WhatsAppDetails = ({ isAnomaly, scores, measurement, render }) => {
             </Box>
           </Flex>
         </Box>
-        {tcp_connect && tcp_connect.length > 0 &&
+        {Array.isArray(tcp_connect) && tcp_connect.length > 0 &&
           <React.Fragment>
             <Heading h={4}> <FormattedMessage id='Measurement.Details.WhatsApp.Endpoint.Status.Heading' /> </Heading>
             {tcp_connect.map((connection, index) => (

--- a/cypress/integration/measurement.e2e.js
+++ b/cypress/integration/measurement.e2e.js
@@ -61,6 +61,10 @@ describe('Measurement Page Tests', () => {
       cy.heroHasColor(errorColor)
         .contains('Error')
     })
+
+    it('renders a measurement with missing data in test_keys', () => {
+      cy.visit('/measurement/20210128T090057Z_webconnectivity_IT_30722_n1_WOS6jGJBP1UMopM9?input=http%3A%2F%2Fvoice.yahoo.jajah.com%2F')
+    })
   })
 
   describe('Telegram Tests', () => {


### PR DESCRIPTION
This fixes the problem in pages like https://explorer.ooni.org/measurement/20210128T090057Z_webconnectivity_IT_30722_n1_WOS6jGJBP1UMopM9?input=http%3A%2F%2Fvoice.yahoo.jajah.com%2F where test_keys has null values in `tcp_connect`, `queries.[].answers` ﻿
We explicitly check that the value exists and is an `Array`

