### PR TITLE
Improve the labels of the mat

### DIFF
--- a/components/aggregation/mat/Charts.js
+++ b/components/aggregation/mat/Charts.js
@@ -19,7 +19,7 @@ export const StackedBarChart = ({data, cols, indexBy}) => (
     data={data}
     keys={cols}
     indexBy={indexBy}
-    margin={{ top: 50, right: 130, bottom: 50, left: 60 }}
+    margin={{ top: 50, right: 130, bottom: 100, left: 80 }}
     padding={0.3}
     colors={colorFunc}
     borderColor={{ from: 'color', modifiers: [ [ 'darker', 1.6 ] ] }}
@@ -28,18 +28,18 @@ export const StackedBarChart = ({data, cols, indexBy}) => (
     axisBottom={{
       tickSize: 5,
       tickPadding: 5,
-      tickRotation: 0,
+      tickRotation: 45,
       legend: 'day',
-      legendPosition: 'middle',
+      legendPosition: 'left',
       legendOffset: 32
     }}
     axisLeft={{
       tickSize: 5,
       tickPadding: 5,
       tickRotation: 0,
-      legend: 'msmt count',
+      legend: 'measurement count',
       legendPosition: 'middle',
-      legendOffset: -40
+      legendOffset: -60
     }}
     labelSkipWidth={12}
     labelSkipHeight={12}


### PR DESCRIPTION
This PR rotates the date labels by 45 degrees so they become more legible and moves the y axis label outside of the number area to improve legibility.