### PR TITLE
FIX: Valid Domain Issue when used backslash

### DIFF
--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -144,7 +144,7 @@ class FilterSidebar extends React.Component {
       case 'domainFilter':
         var domainValue = e.target.value
         // eslint-disable-next-line no-useless-escape
-        var domainRegEx = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,7}(:[0-9]{1,5})?(\/)?$/
+        var domainRegEx = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,7}(:[0-9]{1,5})?(\|\/)?$/
         var ipRegEx = /^(([0-9]{1,3})\.){3}([0-9]{1,3})/
         if (domainValue && domainValue.match(domainRegEx) === null
           && domainValue.match(ipRegEx) === null) {


### PR DESCRIPTION
In this PR, I have addressed issues #468 and #457. 

## Problem

OONI Explorer is searching and giving no results for a domain that has backslash `/` at the end. 

![search with backslash](https://user-images.githubusercontent.com/44341551/111771514-a0a87580-88cd-11eb-8448-09d816bfaa15.png)

When searched without backslash `/`, it was giving the desired results.

![Search without backslash](https://user-images.githubusercontent.com/44341551/111771641-c03f9e00-88cd-11eb-8889-642548c44d0d.png)

## Solution

I have improved the regex so that now it is giving the appropriate error message.

![Solution](https://user-images.githubusercontent.com/44341551/111771960-1ca2bd80-88ce-11eb-8a4a-81270305f8b1.png)

