### PR TITLE
[FIX] Allowing filter domain inputs with http/https and extracting usable domain URLs from the input string

### DIFF
--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -245,7 +245,7 @@ class FilterSidebar extends React.Component {
 
   onClickApplyFilter() {
     var domainValue = this.getUsableDomainValue()
-    console.log('domainValue final: ', domainValue)
+    
     this.props.onApplyFilter({
       domainFilter: domainValue,
       onlyFilter: this.state.onlyFilter,

--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -144,7 +144,7 @@ class FilterSidebar extends React.Component {
       case 'domainFilter':
         var domainValue = e.target.value
         // eslint-disable-next-line no-useless-escape
-        var domainRegEx = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,7}(:[0-9]{1,5})?(\/)?$/
+        var domainRegEx = /^(https?:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,7}(:[0-9]{1,5})?(\/)?$/
         var ipRegEx = /^(([0-9]{1,3})\.){3}([0-9]{1,3})/
         if (domainValue && domainValue.match(domainRegEx) === null
           && domainValue.match(ipRegEx) === null) {
@@ -222,9 +222,32 @@ class FilterSidebar extends React.Component {
     }
   }
 
+  // Function to get usable domain URL
+  // Eg. https://www.twitter.com/ is converted to twitter.com
+  getUsableDomainValue() {
+    var domainValue = this.state.domainFilter
+
+    if (/^(https?:\/\/)/.test(domainValue)) {
+      var domainValueWithoutHttp = domainValue.replace(/^(https?:\/\/)/, '')
+      domainValue = domainValueWithoutHttp
+    }
+    if(/^(www\.)/.test(domainValue)) {
+      var domainValueWithoutWWW = domainValue.replace(/^(www\.)/, '')
+      domainValue = domainValueWithoutWWW
+    }
+    if(/(\/)$/.test(domainValue)) {
+      var domainValueWithoutTrailingSlash = domainValue.replace(/(\/)$/, '')
+      domainValue = domainValueWithoutTrailingSlash
+    }
+
+    return domainValue ? domainValue : this.state.domainFilter
+  }
+
   onClickApplyFilter() {
+    var domainValue = this.getUsableDomainValue()
+    console.log('domainValue final: ', domainValue)
     this.props.onApplyFilter({
-      domainFilter: this.state.domainFilter,
+      domainFilter: domainValue,
       onlyFilter: this.state.onlyFilter,
       testNameFilter: this.state.testNameFilter,
       countryFilter: this.state.countryFilter,


### PR DESCRIPTION
This PR is in response to the issues #457 and #468

- [x] Entering a complete URL with 'http://' or 'https://' does not present the 'Invalid domain' message anymore

![Screenshot from 2021-03-19 17 12 35](https://user-images.githubusercontent.com/32863230/111775132-5aa3df80-88d6-11eb-89f1-73ef39faff54.jpeg)


- [x] The usable domain (eg. twitter.com) is extracted from the complete input domain string. The process involves: 
* Checking for, and if present, removing the protocol string (http:// or https://) from the _beginning_ of the input domain string
* Checking for, and if present, removing 'www.' from the _beginning_ of the input domain string
* Checking for, and if present, removing the forward slash (/) from the _end_ of the input domain string

Thus for an input domain string of _https://www.twitter.com/_ , the extracted usable domain string is **_twitter.com_** which yields the correct search result

@sarathms  @hellais  kindly review the changes
