### PR TITLE
[ENHANCEMENT] Date and time format inconsistency in the search results

### DIFF
--- a/components/search/ResultsList.js
+++ b/components/search/ResultsList.js
@@ -330,7 +330,17 @@ const ResultItem = ({
                   <ASNBox asn={probe_asn} />
                 </Box>
                 <Box width={5/16}>
-                  {moment.utc(measurement_start_time).format('YYYY-MM-DD HH:mm [UTC]')}
+                  {
+                    useIntl().formatDate(measurement_start_time, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: '2-digit',
+                      hour: '2-digit',
+                      minute: 'numeric',
+                      timeZone: 'UTC',
+                      timeZoneName: 'short'
+                    })
+                  }
                 </Box>
                 <Box width={5/16}>
                   {testDisplayName}


### PR DESCRIPTION
This is in response to the issue #515 

This PR:
- [x] Fixes the inconsistency in the date and time formats between search result elements and the measurements page

As of now, the measurements page presents the date and time in this format: 

![Screenshot from 2021-03-19 18 11 12](https://user-images.githubusercontent.com/32863230/111782416-00f3e300-88df-11eb-8fdc-aa626434f76c.jpeg)

And the Search results have a different format for showing the same:

![Screenshot from 2021-03-19 18 10 38](https://user-images.githubusercontent.com/32863230/111782612-3d274380-88df-11eb-9db5-edac4e221c75.jpeg)

This PR aims to bring a consistency in the format of the displayed date and time:

![Screenshot from 2021-03-19 18 10 56](https://user-images.githubusercontent.com/32863230/111782497-136e1c80-88df-11eb-893f-4fa40ebf9ca4.jpeg)