### PR TITLE
[ENHANCEMENT] Inconsistent date-time in measurement page summary text

### DIFF
--- a/components/measurement/SummaryText.js
+++ b/components/measurement/SummaryText.js
@@ -16,7 +16,6 @@ const SummaryText = ({
 }) => {
   const intl = useIntl()
   const metadata = getTestMetadata(testName)
-  const formattedDate = moment(date).format('LL')
   const formattedDateTime = intl.formatDate(moment.utc(date).toDate(), {
     year: 'numeric',
     month: 'long',
@@ -37,7 +36,7 @@ const SummaryText = ({
           testName: `[${metadata.name}](${metadata.info})`,
           network: network,
           country: country,
-          date: `<abbr title='${formattedDateTime}'>${formattedDate}</abbr>`
+          date: formattedDateTime
         }}
       />
   } else {


### PR DESCRIPTION
As stated in issue #541, it only showed the date on IM test pages

`On March 17, 2021, WhatsApp was reachable on AS7922 in United States`

However in the web_connectivity pages it said

`On March 02, 2020, 9:17 PM UTC, http://prachatai.com was accessible when tested on AS15751 in Ireland.`

It will now show Date and Time in both pages, adding to consistency.

@sarathms I have removed the `<abbr>` and the commented line as you had pointed out in #558 

As for the momentJS dependency, I am looking into possible alternatives. I will open another PR with my attempt at replacing the dependency.
I have closed #558 because the push was on master.

Kindly review :)