### PR TITLE
Hide status filter when irrelevant for selected test

### DIFF
--- a/components/search/Radio.js
+++ b/components/search/Radio.js
@@ -20,12 +20,6 @@ export const RadioGroup = ({
   direction = 'column',
   ...props
 }) => {
-  const [currentValue, setCurrentValue] = useState(value)
-
-  const onChangeCallback = useCallback((event) => {
-    setCurrentValue(event.target.value)
-    onChange(event.target.value)
-  }, [value])
 
   return (
     <Flex flexDirection={direction} {...props}>
@@ -34,8 +28,8 @@ export const RadioGroup = ({
           ? child
           : React.cloneElement(child, {
             name: name,
-            checked: child.props.value === currentValue,
-            onChange: onChangeCallback,
+            checked: child.props.value === value,
+            onChange: (e) => { onChange(e.target.value) },
           })
       ))}
     </Flex>

--- a/components/search/ResultsList.js
+++ b/components/search/ResultsList.js
@@ -43,7 +43,9 @@ const testsWithStates = [
   'whatsapp',
   'facebook_messenger',
   'tor',
-  'psiphon'
+  'psiphon',
+  'http_header_field_manipulation',
+  'http_invalid_request_line',
 ]
 
 const imTests = [

--- a/cypress/integration/search.e2e.js
+++ b/cypress/integration/search.e2e.js
@@ -66,7 +66,6 @@ describe('Seearch Page Tests', () => {
     })
 
     cy.get('[data-test-id="testname-filter"]').select('Telegram')
-    cy.get('label').contains('Confirmed').click()
     cy.get('label').contains('Anomalies').click()
     cy.get('label').contains('All Results').click()
 


### PR DESCRIPTION
Fixes #581

Additionally,

﻿- Show only relevant status filter for tests (e.g no 'Confirmed' for 'telegram')
- Show anomaly status for middlebox tests in search results. Not directly related, but bundling this change in here.
