### PR TITLE
Test legacy pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,41 +1,28 @@
 {
-    "env": {
-        "browser": true,
-        "es6": true
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:cypress/recommended"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
     },
-    "extends": [
-      "eslint:recommended",
-      "plugin:react/recommended"
-    ],
-    "parserOptions": {
-        "ecmaFeatures": {
-            "experimentalObjectRestSpread": true,
-            "jsx": true
-        },
-        "ecmaVersion": 2020,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react"
-    ],
-    "rules": {
-        "indent": [
-            "error",
-            2
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ],
-        "react/prop-types": ["warn"]
-    },
-    "ignorePatterns": ["components/vendor", "static"]
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "plugins": ["react", "cypress"],
+  "rules": {
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "single"],
+    "semi": ["error", "never"],
+    "react/prop-types": ["warn"]
+  },
+  "ignorePatterns": ["components/vendor", "static"]
 }

--- a/cypress/integration/countries.e2e.js
+++ b/cypress/integration/countries.e2e.js
@@ -1,5 +1,3 @@
-/* global describe, it, cy, before */
-
 describe('Countries Page Tests', () => {
 
   before(() => {

--- a/cypress/integration/country.e2e.js
+++ b/cypress/integration/country.e2e.js
@@ -1,5 +1,3 @@
-/* global describe, it, cy, before */
-
 describe('Country Page Tests', () => {
 
   before(() => {

--- a/cypress/integration/home.e2e.js
+++ b/cypress/integration/home.e2e.js
@@ -1,5 +1,3 @@
-/* global describe, it, cy, before */
-
 describe('Home Page Tests', () => {
 
   before(() => {

--- a/cypress/integration/legacy.e2e.js
+++ b/cypress/integration/legacy.e2e.js
@@ -1,0 +1,38 @@
+describe('Seearch Page Tests', () => {
+
+  it('can lookup legacy data', () => {
+    cy.visit('/search?until=2015-03-31&since=2014-12-01')
+  })
+
+  it('shows page full of results', () => {
+    cy.get('[data-test-id="results-list"]').children('a').should('have.length.of.at.least', 49)
+  })
+
+  it('can access "HTTP Hosts" measurements', () => {
+    cy.get('select[name="testNameFilter"]').select('http_host')
+    cy.get('button').contains('Filter Results').should('not.be.disabled').click()
+    cy.get('[data-test-id="results-list"]', { timeout: 10000 })
+      .children('a')
+      .should('have.length.of.at.least', 49)
+      .each(($el) => {
+        cy.wrap($el)
+          .should('have.attr', 'href')
+          .and('match', /measurement/)
+          .then((href) => {
+            cy.request(href)
+          })
+      })
+  })
+
+  it.only('legacy measurement page shows enough information', () => {
+    cy.visit('/measurement/20150330T231214Z_bLcnlMHNRrNezvvmUePFtkbJNDglhMvTNoivcUMZqpUjXhkHlR?input=https%3A%2F%2Fcryptbin.com')
+    cy.contains('Country').siblings().contains('Canada')
+    cy.contains('Network').siblings().contains('AS812')
+    cy.contains('Date & Time').siblings().contains('March 30, 2015, 11:12 PM UTC')
+    // Raw measurement rendered?
+  })
+
+
+
+
+})

--- a/cypress/integration/measurement.e2e.js
+++ b/cypress/integration/measurement.e2e.js
@@ -1,4 +1,3 @@
-/* global describe, it, cy */
 describe('Measurement Page Tests', () => {
 
   const normalColor = 'rgb(47, 158, 68)'

--- a/cypress/integration/search.e2e.js
+++ b/cypress/integration/search.e2e.js
@@ -1,5 +1,3 @@
-/* global describe, it, cy, before, Cypress, expect */
-
 describe('Seearch Page Tests', () => {
 
   before(() => {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "babel-plugin-react-intl": "^3.2.0",
     "cypress": "^5.2.0",
     "eslint": "^7.20.0",
+    "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-react": "^7.22.0",
     "glob": "^7.1.6",
     "mustache": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,6 +2494,13 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-plugin-cypress@^2.11.3:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.3.tgz#54ee4067aa8192aa62810cd35080eb577e191ab7"
+  integrity sha512-hOoAid+XNFtpvOzZSNWP5LDrQBEJwbZwjib4XJ1KcRYKjeVj0mAmPmucG4Egli4j/aruv+Ow/acacoloWWCl9Q==
+  dependencies:
+    globals "^11.12.0"
+
 eslint-plugin-react@^7.22.0:
   version "7.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz#3d1c542d1d3169c45421c1215d9470e341707269"
@@ -3116,6 +3123,11 @@ globals@^11.1.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
   integrity sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==
+
+globals@^11.12.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^12.1.0:
   version "12.4.0"


### PR DESCRIPTION
Fixes #554 

Searches for measurements between `2014-12-01` and `2015-03-31` and checks if the measurement pages render properly and if basic information is shown on those pages.