### PR TITLE
Fix debug context issues

### DIFF
--- a/components/aggregation/DebugContext.js
+++ b/components/aggregation/DebugContext.js
@@ -41,4 +41,13 @@ export const DebugProvider = ({ children }) => {
   )
 }
 
+export const withDebugProvider = (Component) => {
+  const WithDebugProvider = ({ ...props }) => (
+    <DebugProvider>
+      <Component {...props} />
+    </DebugProvider>
+  )
+  return WithDebugProvider
+}
+
 export const useDebugContext = () => useContext(DebugContext)

--- a/pages/experimental/mat.js
+++ b/pages/experimental/mat.js
@@ -18,7 +18,7 @@ import { FunnelChart } from '../../components/aggregation/mat/FunnelChart'
 import { GridChart } from '../../components/aggregation/mat/GridChart'
 import { Form } from '../../components/aggregation/mat/Form'
 import { axiosResponseTime } from '../../components/axios-plugins'
-import { DebugProvider, useDebugContext } from '../../components/aggregation/DebugContext'
+import { withDebugProvider, useDebugContext } from '../../components/aggregation/DebugContext'
 import { Debug } from '../../components/aggregation/Debug'
 
 const baseURL = process.env.NEXT_PUBLIC_MEASUREMENTS_URL
@@ -143,12 +143,12 @@ MeasurementAggregationToolkit.propTypes = {
   )
 }
 
-function DebuggableMAT({ testNames }) {
-  return (
-    <DebugProvider>
-      <MeasurementAggregationToolkit testNames={testNames} />
-    </DebugProvider>
-  )
-}
+// function DebuggableMAT({ testNames }) {
+//   return (
+//     <DebugProvider>
+//       <MeasurementAggregationToolkit testNames={testNames} />
+//     </DebugProvider>
+//   )
+// }
 
-export default DebuggableMAT
+export default withDebugProvider(MeasurementAggregationToolkit)

--- a/pages/experimental/website/[probe_cc].js
+++ b/pages/experimental/website/[probe_cc].js
@@ -6,6 +6,7 @@ import { Container } from 'ooni-components'
 import Layout from '../../../components/Layout'
 import NavBar from '../../../components/NavBar'
 import WebsiteInCountry from '../../../components/aggregation/website/WebsiteInCountry'
+import { withDebugProvider } from '../../../components/aggregation/DebugContext'
 
 const WebsiteInCountryPage = () => {
   const router = useRouter()
@@ -26,4 +27,4 @@ const WebsiteInCountryPage = () => {
   )
 }
 
-export default WebsiteInCountryPage
+export default withDebugProvider(WebsiteInCountryPage)

--- a/pages/experimental/website/index.js
+++ b/pages/experimental/website/index.js
@@ -15,6 +15,7 @@ import Global from '../../../components/aggregation/website/Global'
 import FForm from '../../../components/aggregation/website/Form'
 import { paramsToQuery, queryToParams } from '../../../components/aggregation/website/queryUtils'
 import { Debug } from '../../../components/aggregation/Debug'
+import { withDebugProvider } from '../../../components/aggregation/DebugContext'
 
 const Form = React.memo(FForm)
 
@@ -91,4 +92,4 @@ const WebsiteAnalytics = () => {
   )
 }
 
-export default WebsiteAnalytics
+export default withDebugProvider(WebsiteAnalytics)


### PR DESCRIPTION
Refactors `pages/experimental/website` to use `DebugContext` to show render the Debug box. `DebugContext` introduced during MAT related work and was not ported over to this page at that time. Both pages use the same Debug component.