### PR TITLE
Show failed measurements in search results

### DIFF
--- a/components/colors.js
+++ b/components/colors.js
@@ -1,7 +1,7 @@
 import { theme } from 'ooni-components'
 
 export const colorNormal = theme.colors.green7
-export const colorError = theme.colors.yellow5
+export const colorError = theme.colors.gray4
 export const colorConfirmed = theme.colors.red8
 export const colorAnomaly = theme.colors.yellow8
 export const colorEmpty = theme.colors.gray3

--- a/components/search/ResultsList.js
+++ b/components/search/ResultsList.js
@@ -257,7 +257,7 @@ const ResultInput = styled.div`
   color: ${props => props.theme.colors.gray5};
 `
 
-const getIndicators = ({ test_name, testDisplayName, scores = {}, confirmed, anomaly, intl }) => {
+const getIndicators = ({ test_name, testDisplayName, scores = {}, confirmed, anomaly, failure, intl }) => {
   let color = '', tag = null
   if (testsWithStates.includes(test_name)) {
     if (imTests.includes(test_name) && Object.entries(scores).length === 0) {
@@ -275,15 +275,13 @@ const getIndicators = ({ test_name, testDisplayName, scores = {}, confirmed, ano
           {intl.formatMessage(messages[`${computedMessageIdPrefix}.Blocked`])}
         </ResultTagFilled>
       )
-    /* XXX hotfix due to all measurements showing failures
-    } else if (msmt.failure === true) {
+    } else if (failure === true) {
       color = colorError
       tag = (
         <ResultTagHollow>
           {intl.formatMessage(messages[`${computedMessageIdPrefix}.Error`])}
         </ResultTagHollow>
       )
-    */
     } else if (blockingType !== undefined) {
       color = colorAnomaly
       tag = (


### PR DESCRIPTION
This was previously disabled because of a backend bug that
marked all measurements as errors. We now have more accurate flags
to show failed measurements in the search results.
﻿
