### PR TITLE
Mat title

### DIFF
--- a/components/aggregation/mat/GridChart.js
+++ b/components/aggregation/mat/GridChart.js
@@ -1,12 +1,17 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { ResponsiveBar } from '@nivo/bar'
-import { Heading, Flex, Box } from 'ooni-components'
+import { Heading, Flex, Box, Text } from 'ooni-components'
 import OONILogo from 'ooni-components/components/svgs/logos/OONI-HorizontalMonochrome.svg'
 
 import RowChart from './RowChart'
 import { useDebugContext } from '../DebugContext'
 import { defaultRangeExtractor, useVirtual } from 'react-virtual'
+import { colorMap } from './colorMap'
+
+import { getSubtitleStr } from './StackedBarChart'
+
+import CountryNameLabel from './CountryNameLabel'
 
 const GRID_ROW_CSS_SELECTOR = 'outerListElement'
 
@@ -20,6 +25,18 @@ export function getDatesBetween(startDate, endDate) {
   return dateArray
 }
 
+const Legend = ({label, color}) => {
+  return (
+    <Flex alignItems='center'>
+      <Box pr={2}>
+        <div style={{ width: '10px', height: '10px', backgroundColor: color }} />
+      </Box>
+      <Box>
+        <Text>{label}</Text>
+      </Box>
+    </Flex>
+  )
+}
 const reshapeChartData = (data, query) => {
   const rows = []
   const rowLabels = {}
@@ -138,12 +155,32 @@ const GridChart = ({ data, query, height }) => {
       <Box alignSelf='flex-end' sx={{ position: 'absolute', opacity: 0.8, top: 16, left: 16 }}>
         <OONILogo height='32px' />
       </Box>
-      <Flex flexDirection='column' my={4}>
+      <Flex flexDirection='column'>
         {/* Fake axis on top of list. Possible alternative: dummy chart with axis and valid tickValues */}
         <Flex>
           <Box width={2/16}>
           </Box>
-          <Box className='xAxis' sx={{ width: '100%', height: '70px' }}>
+          <Box className='xAxis' sx={{ width: '100%', height: '170px' }}>
+            <Heading h={3} textAlign='center'>
+              <CountryNameLabel countryCode={query.probe_cc} />
+            </Heading>
+            <Heading h={5} fontWeight='normal' textAlign='center'>
+              {getSubtitleStr(query)}
+            </Heading>
+            <Flex justifyContent='center' my={2}>
+              <Box pr={2}>
+                <Legend label='ok_count' color={colorMap['ok_count']} />
+              </Box>
+              <Box pr={2}>
+                <Legend label='confirmed_count' color={colorMap['confirmed_count']} />
+              </Box>
+              <Box pr={2}>
+                <Legend label='anomaly_count' color={colorMap['anomaly_count']} />
+              </Box>
+              <Box pr={2}>
+                <Legend label='failure_count' color={colorMap['failure_count']} />
+              </Box>
+            </Flex>
             <ResponsiveBar
               data={xAxisData}
               indexBy={query.axis_x}

--- a/components/aggregation/mat/GridChart.js
+++ b/components/aggregation/mat/GridChart.js
@@ -157,10 +157,10 @@ const GridChart = ({ data, query, height }) => {
       </Box>
       <Flex flexDirection='column'>
         {/* Fake axis on top of list. Possible alternative: dummy chart with axis and valid tickValues */}
-        <Flex>
+        <Flex justifyContent={'center'}>
           <Box width={2/16}>
           </Box>
-          <Box className='xAxis' sx={{ width: '100%', height: '170px' }}>
+          <Flex flexDirection={['column']}>
             <Heading h={3} textAlign='center'>
               <CountryNameLabel countryCode={query.probe_cc} />
             </Heading>
@@ -181,6 +181,12 @@ const GridChart = ({ data, query, height }) => {
                 <Legend label='failure_count' color={colorMap['failure_count']} />
               </Box>
             </Flex>
+          </Flex>
+        </Flex>
+        <Flex>
+          <Box width={2/16}>
+          </Box>
+          <Box className='xAxis' sx={{ width: '100%', height: '70px' }}>
             <ResponsiveBar
               data={xAxisData}
               indexBy={query.axis_x}

--- a/components/aggregation/mat/StackedBarChart.js
+++ b/components/aggregation/mat/StackedBarChart.js
@@ -16,7 +16,7 @@ const colorFunc = (d) => colorMap[d.id] || '#ccc'
 // const parseDate = d3.timeParse("%Y-%m-%d %H:%M:%S")
 // const formatDay = d3.timeFormat("%Y-%m-%d")
 
-const getSubtitleStr = (query) => {
+export const getSubtitleStr = (query) => {
   let str = `${query.test_name}`
   if (query.input) {
     str += `, ${query.input}`

--- a/components/aggregation/mat/StackedBarChart.js
+++ b/components/aggregation/mat/StackedBarChart.js
@@ -16,6 +16,20 @@ const colorFunc = (d) => colorMap[d.id] || '#ccc'
 // const parseDate = d3.timeParse("%Y-%m-%d %H:%M:%S")
 // const formatDay = d3.timeFormat("%Y-%m-%d")
 
+const getSubtitleStr = (query) => {
+  let str = `${query.test_name}`
+  if (query.input) {
+    str += `, ${query.input}`
+  }
+  if (query.category_code) {
+    str += `, ${query.category_code}`
+  }
+  if (query.probe_asn) {
+    str += `, ${query.probe_asn}`
+  }
+  return str
+}
+
 export const StackedBarChart = ({ data, query }) => {
   const intl = useIntl()
   const [link, setLink] = useState(false)
@@ -62,7 +76,14 @@ export const StackedBarChart = ({ data, query }) => {
   return (
     <Flex flexDirection={['column']} height={'100%'} sx={{ position: 'relative' }}>
       <Flex justifyContent='space-between' alignItems='center'>
-        <Heading h={3}><CountryNameLabel countryCode={query.probe_cc} /></Heading>
+        <Box>
+        <Heading h={3}>
+          <CountryNameLabel countryCode={query.probe_cc} />
+        </Heading>
+        <Heading h={5} fontWeight='normal'>
+          {getSubtitleStr(query)}
+        </Heading>
+        </Box>
         <Box>
           {link ? (
           <Flex alignItems='center'>
@@ -140,7 +161,7 @@ export const StackedBarChart = ({ data, query }) => {
           onClick={onClick}
         />
       </Box>
-      <Box sx={{ position: 'absolute', opacity: 0.8, bottom: -70, right: 0 }}>
+      <Box sx={{ position: 'absolute', opacity: 0.8, bottom: -85, right: 0 }}>
         <OONILogo height='32px' />
       </Box>
     </Flex>

--- a/components/aggregation/mat/TableView.js
+++ b/components/aggregation/mat/TableView.js
@@ -259,7 +259,7 @@ const TableView = ({ data, query }) => {
     return rows
   }, [rows, selectedFlatRows])
 
-  const [chartPanelHeight, setChartPanelHeight] = useState(250)
+  const [chartPanelHeight, setChartPanelHeight] = useState(800)
 
   const onPanelResize = useCallback((width, height) => {
     console.log(`resized height: ${height}`)


### PR DESCRIPTION
This PR achieves the following:
* Add support for displaying a subtitle with metadata about the filters selected in the single axis charts
* Display a title and subtitle in the 2 axis charts
* Add legend to 2 axis charts
* Fix positioning of the OONI logo
* Load the chart with a default height of 800px