### PR TITLE
Generate ChartHeader based on MATContext

### DIFF
--- a/components/aggregation/mat/ChartHeader.js
+++ b/components/aggregation/mat/ChartHeader.js
@@ -1,0 +1,66 @@
+import { Heading, Flex, Box, Text } from 'ooni-components'
+import { useIntl } from 'react-intl'
+
+import { useMATContext } from './MATContext'
+import CountryNameLabel from './CountryNameLabel'
+import { colorMap } from './colorMap'
+
+const Legend = ({label, color}) => {
+  return (
+    <Flex alignItems='center'>
+      <Box pr={2}>
+        <div style={{ width: '10px', height: '10px', backgroundColor: color }} />
+      </Box>
+      <Box>
+        <Text>{label}</Text>
+      </Box>
+    </Flex>
+  )
+}
+
+
+export const getSubtitleStr = (query) => {
+  let str = `${query.test_name}`
+  if (query.input) {
+    str += `, ${query.input}`
+  }
+  if (query.category_code) {
+    str += `, ${query.category_code}`
+  }
+  if (query.probe_asn) {
+    str += `, ${query.probe_asn}`
+  }
+  return str
+}
+
+export const ChartHeader = () => {
+  const intl = useIntl()
+  const [query] = useMATContext()
+
+  const subTitle = getSubtitleStr(query)
+
+  return (
+    <Flex flexDirection={['column']}>
+      <Heading h={3} textAlign='center'>
+        <CountryNameLabel countryCode={query.probe_cc} />
+      </Heading>
+      <Heading h={5} fontWeight='normal' textAlign='center'>
+        {subTitle}
+      </Heading>
+      <Flex justifyContent='center' my={2}>
+        <Box pr={2}>
+          <Legend label='ok_count' color={colorMap['ok_count']} />
+        </Box>
+        <Box pr={2}>
+          <Legend label='confirmed_count' color={colorMap['confirmed_count']} />
+        </Box>
+        <Box pr={2}>
+          <Legend label='anomaly_count' color={colorMap['anomaly_count']} />
+        </Box>
+        <Box pr={2}>
+          <Legend label='failure_count' color={colorMap['failure_count']} />
+        </Box>
+      </Flex>
+    </Flex>
+  )
+}

--- a/components/aggregation/mat/GridChart.js
+++ b/components/aggregation/mat/GridChart.js
@@ -7,31 +7,17 @@ import OONILogo from 'ooni-components/components/svgs/logos/OONI-HorizontalMonoc
 import RowChart, { chartMargins } from './RowChart'
 import { useDebugContext } from '../DebugContext'
 import { defaultRangeExtractor, useVirtual } from 'react-virtual'
-import { colorMap } from './colorMap'
-import { getSubtitleStr } from './StackedBarChart'
-import CountryNameLabel from './CountryNameLabel'
-import { getRowLabel } from './labels'
 import { fillDataInMissingDates, getDatesBetween } from './computations'
 import { getXAxisTicks } from './timeScaleXAxis'
 import { useMATContext } from './MATContext'
+import { ChartHeader } from './ChartHeader'
+import { getRowLabel } from './labels'
 
 const GRID_ROW_CSS_SELECTOR = 'outerListElement'
 const ROW_HEIGHT = 70
 const GRID_MAX_HEIGHT = 600
 const retainMountedRows = false
 
-const Legend = ({label, color}) => {
-  return (
-    <Flex alignItems='center'>
-      <Box pr={2}>
-        <div style={{ width: '10px', height: '10px', backgroundColor: color }} />
-      </Box>
-      <Box>
-        <Text>{label}</Text>
-      </Box>
-    </Flex>
-  )
-}
 const reshapeChartData = (data, query, isGrouped) => {
   const rows = []
   const rowLabels = {}
@@ -168,28 +154,8 @@ const GridChart = ({ data, isGrouped = true, height = 'auto' }) => {
         <Flex justifyContent={'center'}>
           <Box width={2/16}>
           </Box>
-          <Flex flexDirection={['column']}>
-            <Heading h={3} textAlign='center'>
-              <CountryNameLabel countryCode={query.probe_cc} />
-            </Heading>
-            <Heading h={5} fontWeight='normal' textAlign='center'>
-              {getSubtitleStr(query)}
-            </Heading>
-            <Flex justifyContent='center' my={2}>
-              <Box pr={2}>
-                <Legend label='ok_count' color={colorMap['ok_count']} />
-              </Box>
-              <Box pr={2}>
-                <Legend label='confirmed_count' color={colorMap['confirmed_count']} />
-              </Box>
-              <Box pr={2}>
-                <Legend label='anomaly_count' color={colorMap['anomaly_count']} />
-              </Box>
-              <Box pr={2}>
-                <Legend label='failure_count' color={colorMap['failure_count']} />
-              </Box>
-            </Flex>
-          </Flex>
+          <ChartHeader />
+
         </Flex>
         <Flex>
           <Box width={2/16}>

--- a/components/aggregation/mat/MATContext.js
+++ b/components/aggregation/mat/MATContext.js
@@ -15,8 +15,8 @@ export const defaultMATContext = {
   category_code: ''
 }
 
-export const MATContextProvider = ({ children, ...initalContext }) => {
-  const [state, setState] = useState({...defaultMATContext, ...initalContext})
+export const MATContextProvider = ({ children, ...initialContext }) => {
+  const [state, setState] = useState({...defaultMATContext, ...initialContext})
 
   const { query } = useRouter()
 
@@ -24,19 +24,16 @@ export const MATContextProvider = ({ children, ...initalContext }) => {
     setState(state =>
       Object.assign({},
         state,
-        Object.keys(defaultMATContext).reduce((o, k) => {
-          if (updates[k]) {
-            o[k] = updates[k]
-          }
-          return o
-        }, {})
+        defaultMATContext,
+        initialContext,
+        updates
       )
     )
-  }, [])
+  }, [initialContext])
 
   useEffect(() => {
     stateReducer(query)
-  }, [query, stateReducer])
+  }, [query])
 
   return (
     <MATStateContext.Provider value={{...state, updateMATContext: stateReducer}}>

--- a/components/aggregation/mat/StackedBarChart.js
+++ b/components/aggregation/mat/StackedBarChart.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { ResponsiveBar } from '@nivo/bar'
-import { Box, Flex, Heading, Link } from 'ooni-components'
+import { Box, Flex, Link } from 'ooni-components'
 import { IoMdGlobe } from 'react-icons/io'
 import NLink from 'next/link'
 import { useIntl } from 'react-intl'
@@ -9,28 +9,14 @@ import OONILogo from 'ooni-components/components/svgs/logos/OONI-HorizontalMonoc
 
 import { colorMap } from './colorMap'
 import { generateSearchQuery, CustomTooltipNoLink} from './CustomTooltip'
-import CountryNameLabel from './CountryNameLabel'
 import { getXAxisTicks } from './timeScaleXAxis'
 import { fillDataInMissingDates } from './computations'
+import { ChartHeader } from './ChartHeader'
 
 const colorFunc = (d) => colorMap[d.id] || '#ccc'
 
 // const parseDate = d3.timeParse("%Y-%m-%d %H:%M:%S")
 // const formatDay = d3.timeFormat("%Y-%m-%d")
-
-export const getSubtitleStr = (query) => {
-  let str = `${query.test_name}`
-  if (query.input) {
-    str += `, ${query.input}`
-  }
-  if (query.category_code) {
-    str += `, ${query.category_code}`
-  }
-  if (query.probe_asn) {
-    str += `, ${query.probe_asn}`
-  }
-  return str
-}
 
 export const StackedBarChart = ({ data, query }) => {
   const intl = useIntl()
@@ -79,15 +65,8 @@ export const StackedBarChart = ({ data, query }) => {
 
   return (
     <Flex flexDirection={['column']} height={'100%'} sx={{ position: 'relative' }}>
+      <ChartHeader />
       <Flex justifyContent='space-between' alignItems='center'>
-        <Box>
-        <Heading h={3}>
-          <CountryNameLabel countryCode={query.probe_cc} />
-        </Heading>
-        <Heading h={5} fontWeight='normal'>
-          {getSubtitleStr(query)}
-        </Heading>
-        </Box>
         <Box>
           {link ? (
           <Flex alignItems='center'>

--- a/components/aggregation/mat/TableView.js
+++ b/components/aggregation/mat/TableView.js
@@ -248,7 +248,7 @@ const TableView = ({ data, query }) => {
   const [chartPanelHeight, setChartPanelHeight] = useState(800)
 
   const onPanelResize = useCallback((width, height) => {
-    console.log(`resized height: ${height}`)
+    console.debug(`resized height: ${height}`)
     setChartPanelHeight(height - 100)
   }, [])
 


### PR DESCRIPTION
* Uses a single component to show the header on the 1-axis chart, 2-axis chart and the PT dashboard charts.
* Also fixes the issue of the header title not updating when country selection is changed back to 'All Countries'.