### PR TITLE
Tooltip visibility in Circumvention charts

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_MEASUREMENTS_URL=https://api.ooni.io
+NEXT_PUBLIC_AGGREGATION_API=https://backend-fsn.ooni.org
 NEXT_PUBLIC_SENTRY_DSN=https://49af7fff247c445b9a7c98ee21ddfd2f@o155150.ingest.sentry.io/1427510
 NEXT_PUBLIC_EXPLORER_URL=https://explorer.ooni.org

--- a/components/aggregation/mat/CustomBarItem.js
+++ b/components/aggregation/mat/CustomBarItem.js
@@ -55,11 +55,11 @@ export const CustomBarItem = ({
   useEffect(() => {
     // We receive tooltip coordinates in `enableLabel` 
     // to determine if a tooltip is enabled and if the column should be highlighted.
-    if (enableLabel[0] === false) {
+    if (enableLabel === false) {
       hideTooltip()
       setExtraBorderWidth(0)
     } else {
-      setExtraBorderWidth(enableLabel[1] === data.indexValue ? 2 : 0)
+      setExtraBorderWidth(enableLabel === data.indexValue ? 2 : 0)
     }
   }, [data.indexValue, enableLabel, hideTooltip])
 

--- a/components/aggregation/mat/GridChart.js
+++ b/components/aggregation/mat/GridChart.js
@@ -143,10 +143,32 @@ const GridChart = ({ data, isGrouped = true, height = 'auto' }) => {
             />
           </Box>
         </Flex>
-        <VirtualRows
-          itemData={itemData}
-          tooltipIndex={tooltipIndex}
-        />
+        {/* Use a virtual list only for higher count of rows */}
+        {rows.length < 10 ? (
+          <Flex
+            className='outerListElement'
+            flexDirection='column'
+            style={{
+              height: gridHeight
+            }}
+          >
+            {rows.map((row, index) => 
+              <RowChart
+                key={row}
+                rowIndex={index}
+                data={reshapedData[row]}
+                indexBy={indexBy}
+                height={70}
+                label={rowLabels[row]}
+              />
+            )}
+          </Flex>
+        ) : (
+          <VirtualRows
+            itemData={itemData}
+            tooltipIndex={tooltipIndex}
+          />
+        )}
       </Flex>
     </Flex>
   )

--- a/components/aggregation/mat/MATContext.js
+++ b/components/aggregation/mat/MATContext.js
@@ -12,7 +12,8 @@ export const defaultMATContext = {
   probe_cc: '',
   probe_asn: '',
   input: '',
-  category_code: ''
+  category_code: '',
+  tooltipIndex: [-1, '']
 }
 
 export const MATContextProvider = ({ children, ...initialContext }) => {
@@ -20,13 +21,12 @@ export const MATContextProvider = ({ children, ...initialContext }) => {
 
   const { query } = useRouter()
 
-  const stateReducer = useCallback((updates) => {
+  const stateReducer = useCallback((updates, partial = false) => {
     setState(state =>
-      Object.assign({},
-        state,
-        defaultMATContext,
-        initialContext,
-        updates
+      partial ? (
+        Object.assign({}, state, updates)
+        ) : (
+        Object.assign({}, state, defaultMATContext, initialContext, updates)
       )
     )
   }, [initialContext])

--- a/components/aggregation/mat/RowChart.js
+++ b/components/aggregation/mat/RowChart.js
@@ -40,19 +40,6 @@ const RowChart = ({ data, indexBy, label, height, rowIndex /* width, first, last
 
   const { doneRendering } = useDebugContext()
 
-  // Load the chart with an empty data to avoid
-  // react-spring from working on the actual data during
-  // first render. This forces an update after 1ms with
-  // real data, which appears quick enough with animation disabled
-  // const [chartData, setChartData] = useState([])
-  // useEffect(() => {
-  //   let animation = setTimeout(() => setChartData(data), 1)
-
-  //   return () => {
-  //     clearTimeout(animation)
-  //   }
-  // }, [data])
-
   const chartProps = useMemo(() => ({
     // NOTE: These dimensions are linked to accuracy of the custom axes rendered in
     // <GridChart />

--- a/components/aggregation/mat/TableView.js
+++ b/components/aggregation/mat/TableView.js
@@ -248,8 +248,8 @@ const TableView = ({ data, query }) => {
   const [chartPanelHeight, setChartPanelHeight] = useState(800)
 
   const onPanelResize = useCallback((width, height) => {
-    console.debug(`resized height: ${height}`)
-    setChartPanelHeight(height - 100)
+    // Panel height - (height of ChartHeader + XAxis) = Height of RowCharts
+    setChartPanelHeight(height - (90 + 62))
   }, [])
 
   return (

--- a/components/aggregation/mat/VirtualRows.js
+++ b/components/aggregation/mat/VirtualRows.js
@@ -1,0 +1,83 @@
+import React, { useCallback } from 'react'
+import { Flex } from 'ooni-components'
+
+import RowChart from './RowChart'
+import { defaultRangeExtractor, useVirtual } from 'react-virtual'
+
+const GRID_ROW_CSS_SELECTOR = 'outerListElement'
+const ROW_HEIGHT = 70
+const retainMountedRows = false
+
+const useKeepMountedRangeExtractor = () => {
+  const renderedRef = React.useRef(new Set())
+
+  const rangeExtractor = React.useCallback(range => {
+    renderedRef.current = new Set([
+      ...renderedRef.current,
+      ...defaultRangeExtractor(range)
+    ])
+    return Array.from(renderedRef.current)
+  }, [])
+
+  return rangeExtractor
+}
+
+export const VirtualRows = ({ itemData, tooltipIndex }) => {
+
+  const {reshapedData, rows, rowLabels, gridHeight, indexBy, yAxis } = itemData
+  const parentRef = React.useRef()
+  const keepMountedRangeExtractor = useKeepMountedRangeExtractor()
+
+  const rowVirtualizer = useVirtual({
+    size: itemData.rows.length,
+    parentRef,
+    estimateSize: useCallback(() => ROW_HEIGHT, []),
+    overscan: 0,
+    rangeExtractor: retainMountedRows ? keepMountedRangeExtractor : defaultRangeExtractor
+  })
+
+  return (
+    <Flex>
+      <div
+        ref={parentRef}
+        className={GRID_ROW_CSS_SELECTOR}
+        style={{
+          height: gridHeight,
+          width: '100%',
+          overflow: 'auto'
+        }}
+      >
+        <div
+          style={{
+            height: `${rowVirtualizer.totalSize}px`,
+            width: '100%',
+            position: 'relative'
+          }}
+        >
+          {rowVirtualizer.virtualItems.map((virtualRow) => (
+            <div
+              key={virtualRow.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: `${virtualRow.size}px`,
+                transform: `translateY(${virtualRow.start}px)`,
+                zIndex: tooltipIndex[0] === virtualRow.index ? 1 : 0
+              }}
+            >
+              <RowChart
+                rowIndex={virtualRow.index}
+                data={reshapedData[rows[virtualRow.index]]}
+                indexBy={indexBy}
+                height={virtualRow.size}
+                label={rowLabels[rows[virtualRow.index]]}
+              />
+            </div>
+          ))}
+          </div>
+        </div>
+    </Flex>
+  )
+}

--- a/components/dashboard/Charts.js
+++ b/components/dashboard/Charts.js
@@ -16,7 +16,7 @@ const swrOptions = {
   dedupingInterval: 10 * 60 * 1000,
 }
 
-const baseURL = process.env.NEXT_PUBLIC_MEASUREMENTS_URL
+const baseURL = process.env.NEXT_PUBLIC_AGGREGATION_API
 axiosResponseTime(axios)
 
 // TODO export from mat.js

--- a/components/dashboard/Charts.js
+++ b/components/dashboard/Charts.js
@@ -6,7 +6,7 @@ import axios from 'axios'
 import { territoryNames } from 'country-util'
 
 import GridChart from '../aggregation/mat/GridChart'
-import { MATContextProvider, useMATContext } from '../aggregation/mat/MATContext'
+import { MATContextProvider } from '../aggregation/mat/MATContext'
 import { withDebugProvider } from '../aggregation/DebugContext'
 import { axiosResponseTime } from '../axios-plugins'
 import { testNames } from '../test-info'
@@ -37,7 +37,6 @@ const fixedQuery = {
 
 const Chart = ({ testName }) => {
   const { query } = useRouter()
-  const [ctx, updateMATContext] = useMATContext()
 
   const derivedQuery = useMemo(() => ({
     ...fixedQuery,

--- a/components/dashboard/Charts.js
+++ b/components/dashboard/Charts.js
@@ -86,6 +86,7 @@ const Chart = ({ testName }) => {
               data={chartData}
               isGrouped={false}
               query={derivedQuery}
+              height={(query?.probe_cc?.split(',').length ?? 10) * 70 }
             />
           )
         )}

--- a/pages/chart/circumvention.js
+++ b/pages/chart/circumvention.js
@@ -59,7 +59,7 @@ const DashboardCircumvention = ({ availableCountries }) => {
 export async function getServerSideProps () {
   let availableCountries = []
   try {
-    const client = axios.create({baseURL: process.env.NEXT_PUBLIC_MEASUREMENTS_URL}) // eslint-disable-line
+    const client = axios.create({baseURL: process.env.NEXT_PUBLIC_AGGREGATION_API}) // eslint-disable-line
     const res = await client.get('/api/_/circumvention_stats_by_country')
     const { results } = res.data
 


### PR DESCRIPTION
This addresses the issue discussed in https://github.com/ooni/explorer/pull/653#issuecomment-1054295488

> When you click on the tooltip for one of the last charts it's displayed hidden below the overflow container. Can we either make the tooltip go out of the container or if we can't do that, make it render above the click instead of below?
> ![Screenshot 2022-02-28 at 15 02 47](https://user-images.githubusercontent.com/424620/155996617-54d81bc3-9198-4531-b115-6b887dbdada0.png)

This is solved by not using virtual lists to render the rows when the counts are low. Currently the threshold is set to `10` rows. 

<img width="925" alt="image" src="https://user-images.githubusercontent.com/700829/157167348-4d63479a-4234-4225-b263-a2c506f1fcfb.png">


When virtualized for longer lists, the scroll action is more natural to make such tooltips visible. However, in most case, the tooltip is anchored in a way that it is visible.

