### PR TITLE
Replace momentjs with dayjs where possible

### DIFF
--- a/components/aggregation/mat/Form.js
+++ b/components/aggregation/mat/Form.js
@@ -8,6 +8,7 @@ import {
 } from 'ooni-components'
 import { countryList } from 'country-util'
 import moment from 'moment'
+import dayjs from 'services/dayjs'
 
 import { categoryCodes } from '../../utils/categoryCodes'
 import DatePicker from '../../DatePicker'
@@ -27,8 +28,8 @@ const optionsAxis = [
   ''
 ]
 
-const tomorrow = moment.utc().add(1, 'day').format('YYYY-MM-DD')
-const lastMonthToday = moment.utc().subtract(30, 'day').format('YYYY-MM-DD')
+const tomorrow = dayjs.utc().add(1, 'day').format('YYYY-MM-DD')
+const lastMonthToday = dayjs.utc().subtract(30, 'day').format('YYYY-MM-DD')
 
 const defaultDefaultValues = {
   probe_cc: '',
@@ -107,9 +108,9 @@ export const Form = ({ onSubmit, testNames, query }) => {
                 isValidDate={currentDate => {
                   const untilValue = getValues('until')
                   if (untilValue && untilValue.length !== 0) {
-                    return currentDate.isBefore(untilValue, 'day')
+                    return dayjs(currentDate).isBefore(untilValue, 'day')
                   } else {
-                    return currentDate.isBefore(tomorrow)
+                    return dayjs(currentDate).isBefore(tomorrow)
                   }
                 }}
               />

--- a/components/aggregation/website/Form.js
+++ b/components/aggregation/website/Form.js
@@ -2,8 +2,9 @@ import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
 import { Flex, Box, Input, Button, Label, Text } from 'ooni-components'
 import { useForm, Controller } from 'react-hook-form'
-import moment from  'moment'
 import styled from 'styled-components'
+import moment from 'moment'
+import dayjs from 'services/dayjs'
 
 import DatePicker from '../../DatePicker'
 
@@ -34,7 +35,7 @@ const Form = ({ onSubmit, initialValues }) => {
   }
 
   const isValidSinceDate = useCallback((value) => {
-    const today = moment.utc()
+    const today = dayjs.utc()
     if (typeof until === 'string' && until.length !== 0) {
       return value.isBefore(until)
     } else {
@@ -43,7 +44,7 @@ const Form = ({ onSubmit, initialValues }) => {
   }, [until])
 
   const isValidUntilDate = useCallback((value) => {
-    const today = moment.utc()
+    const today = dayjs.utc()
     if (typeof until === 'string' && until.length !== 0) {
       return value.isAfter(since) && value.isSameOrBefore(today)
     } else {

--- a/components/country/AppsStatsCircumventionRow.js
+++ b/components/country/AppsStatsCircumventionRow.js
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import {
   NettestVanillaTor
 } from 'ooni-components/dist/icons'
-import moment from 'moment'
+import dayjs from 'services/dayjs'
 
 import { testNames } from '../test-info'
 import { CountryContext } from './CountryContext'
@@ -152,7 +152,7 @@ class AppsStatsCircumventionRow extends React.Component {
               <Box ml='auto'>
                 <FormattedMessage id='Country.Apps.Label.LastTested' />
                 {' '}
-                <strong>{moment.utc(data.last_tested).fromNow()}</strong>
+                <strong>{dayjs.utc(data.last_tested).fromNow()}</strong>
               </Box>
               <Box ml={4}>
                 <CollapseTrigger

--- a/components/country/AppsStatsRow.js
+++ b/components/country/AppsStatsRow.js
@@ -8,7 +8,7 @@ import {
   NettestTelegram,
   NettestFacebookMessenger
 } from 'ooni-components/dist/icons'
-import moment from 'moment'
+import dayjs from 'services/dayjs'
 
 import { testNames } from '../test-info'
 import AppsStatChart from './AppsStatsChart'
@@ -36,8 +36,8 @@ const StyledRow = styled(Box)`
 
 const NetworkRow = ({ asn, app }) => {
   const { countryCode } = useContext(CountryContext)
-  const until = moment.utc().add(1, 'day').format('YYYY-MM-DD')
-  const since = moment.utc().subtract(30, 'days').format('YYYY-MM-DD')
+  const until = dayjs.utc().add(1, 'day').format('YYYY-MM-DD')
+  const since = dayjs.utc().subtract(30, 'day').format('YYYY-MM-DD')
 
   const linkToMeasurements = `/search?probe_cc=${countryCode}&probe_asn=AS${asn}&test_name=${app}&since=${since}&until=${until}`
 
@@ -159,7 +159,7 @@ class AppsStatRow extends React.Component {
           <Box ml='auto'>
             <FormattedMessage id='Country.Apps.Label.LastTested' />
             {' '}
-            <strong>{moment.utc(data.last_tested).fromNow()}</strong>
+            <strong>{dayjs.utc(data.last_tested).fromNow()}</strong>
           </Box>
           <Box ml={4}>
             <CollapseTrigger

--- a/components/country/URLChart.js
+++ b/components/country/URLChart.js
@@ -11,7 +11,7 @@ import {
 } from 'victory'
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
-import moment from 'moment'
+import dayjs from 'services/dayjs'
 
 import {
   colorNormal,
@@ -163,8 +163,8 @@ class URLChart extends React.Component {
       )
     }
 
-    const until = moment.utc().add(1, 'day').format('YYYY-MM-DD')
-    const since30days = moment.utc().subtract(30, 'days').format('YYYY-MM-DD')
+    const until = dayjs.utc().add(1, 'day').format('YYYY-MM-DD')
+    const since30days = dayjs.utc().subtract(30, 'days').format('YYYY-MM-DD')
 
     const yMax = data.reduce((max, item) => (
       (item.total_count > max) ? item.total_count : max

--- a/components/dashboard/Form.js
+++ b/components/dashboard/Form.js
@@ -2,15 +2,16 @@ import { useEffect, useMemo, useState } from 'react'
 import { territoryNames } from 'country-util'
 import { useForm, Controller } from 'react-hook-form'
 import { Box, Flex } from 'ooni-components'
-import moment from 'moment'
 import { MultiSelect } from 'react-multi-select-component'
 import { useIntl } from 'react-intl'
+import moment from 'moment'
+import dayjs from 'services/dayjs'
 
 import { StyledLabel } from '../aggregation/mat/Form'
 import DatePicker from '../DatePicker'
 
-const tomorrow = moment.utc().add(1, 'day').format('YYYY-MM-DD')
-const lastMonthToday = moment.utc().subtract(30, 'day').format('YYYY-MM-DD')
+const tomorrow = dayjs.utc().add(1, 'day').format('YYYY-MM-DD')
+const lastMonthToday = dayjs.utc().subtract(30, 'day').format('YYYY-MM-DD')
 
 const defaultDefaultValues = {
   since: lastMonthToday,

--- a/components/landing/Stats.js
+++ b/components/landing/Stats.js
@@ -9,7 +9,7 @@ import {
   VictoryLegend
 } from 'victory'
 import axios from 'axios'
-import moment from 'moment'
+import dayjs from 'services/dayjs'
 import { Flex, Text, theme } from 'ooni-components'
 import { useIntl } from 'react-intl'
 import useSWR from 'swr'
@@ -148,9 +148,10 @@ const CoverageChart = () => {
               }
             ]}
           />
+          {/* format(parseISO(t), 'MMM\'\'yy' */}
           <VictoryAxis
             tickCount={12}
-            tickFormat={(t) => moment(t).format('MMM[\']YY')}
+            tickFormat={(t) => dayjs(t).format('MMM\'YY')}
           />
           <VictoryAxis
             dependentAxis

--- a/components/landing/Stats.js
+++ b/components/landing/Stats.js
@@ -148,7 +148,6 @@ const CoverageChart = () => {
               }
             ]}
           />
-          {/* format(parseISO(t), 'MMM\'\'yy' */}
           <VictoryAxis
             tickCount={12}
             tickFormat={(t) => dayjs(t).format('MMM\'YY')}

--- a/components/measurement/CommonSummary.js
+++ b/components/measurement/CommonSummary.js
@@ -42,13 +42,13 @@ SummaryItemBox.propTypes = {
 
 const CommonSummary = ({
   color,
-  measurementStartTime,
+  measurement_start_time,
   probe_asn,
   probe_cc,
   country
 }) => {
   const intl = useIntl()
-  const startTime = measurementStartTime
+  const startTime = measurement_start_time
   const network = probe_asn
   const countryCode = probe_cc
 
@@ -92,7 +92,7 @@ const CommonSummary = ({
 }
 
 CommonSummary.propTypes = {
-  measurementStartTime: PropTypes.string.isRequired,
+  measurement_start_time: PropTypes.string.isRequired,
   probe_asn: PropTypes.string.isRequired,
   probe_cc: PropTypes.string.isRequired,
   country: PropTypes.string.isRequired,

--- a/components/measurement/CommonSummary.js
+++ b/components/measurement/CommonSummary.js
@@ -8,6 +8,7 @@ import {
   Text
 } from 'ooni-components'
 import { useIntl } from 'react-intl'
+import dayjs from 'services/dayjs'
 
 import Flag from '../Flag'
 
@@ -60,15 +61,7 @@ const CommonSummary = ({
     </Box>
   </Flex>
 
-  const formattedDate = intl.formatDate(startTime, {
-    year: 'numeric',
-    month: 'long',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: 'numeric',
-    timeZone: 'UTC',
-    timeZoneName: 'short'
-  })
+  const formattedDate = dayjs(startTime).utc().format('MMMM DD, YYYY, hh:mm A [UTC]')
 
   return (
     <React.Fragment>

--- a/components/measurement/CommonSummary.js
+++ b/components/measurement/CommonSummary.js
@@ -42,13 +42,13 @@ SummaryItemBox.propTypes = {
 
 const CommonSummary = ({
   color,
-  test_start_time,
+  measurementStartTime,
   probe_asn,
   probe_cc,
   country
 }) => {
   const intl = useIntl()
-  const startTime = test_start_time
+  const startTime = measurementStartTime
   const network = probe_asn
   const countryCode = probe_cc
 
@@ -92,7 +92,7 @@ const CommonSummary = ({
 }
 
 CommonSummary.propTypes = {
-  test_start_time: PropTypes.string.isRequired,
+  measurementStartTime: PropTypes.string.isRequired,
   probe_asn: PropTypes.string.isRequired,
   probe_cc: PropTypes.string.isRequired,
   country: PropTypes.string.isRequired,

--- a/components/measurement/HeadMetadata.js
+++ b/components/measurement/HeadMetadata.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Head from 'next/head'
 import PropTypes from 'prop-types'
+import { useIntl } from 'react-intl'
 import dayjs from 'services/dayjs'
 import { getTestMetadata } from '../utils'
 
@@ -11,6 +12,7 @@ const HeadMetadata = ({
   date,
   content
 }) => {
+  const intl = useIntl()
   let description = ''
 
   const formattedDate = dayjs(date).utc().format('MMMM D, YYYY, h:m A [UTC]')

--- a/components/measurement/HeadMetadata.js
+++ b/components/measurement/HeadMetadata.js
@@ -15,7 +15,7 @@ const HeadMetadata = ({
   const intl = useIntl()
   let description = ''
 
-  const formattedDate = dayjs(date).utc().format('MMMM D, YYYY, h:m A [UTC]')
+  const formattedDate = dayjs(date).utc().format('MMMM D, YYYY, h:mm:ss A [UTC]')
 
   if (content.formatted) {
     description = content.message

--- a/components/measurement/HeadMetadata.js
+++ b/components/measurement/HeadMetadata.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Head from 'next/head'
 import PropTypes from 'prop-types'
-import { useIntl } from 'react-intl'
+import dayjs from 'services/dayjs'
 import { getTestMetadata } from '../utils'
 
 const HeadMetadata = ({
@@ -11,15 +11,9 @@ const HeadMetadata = ({
   date,
   content
 }) => {
-  const intl = useIntl()
   let description = ''
 
-  const formattedDate = intl.formatDate(date, {
-    timeZone: 'UTC',
-    timeZoneName: 'short',
-    day: 'numeric', month: 'long', year: 'numeric',
-    hour: 'numeric', minute: 'numeric', second: 'numeric'
-  })
+  const formattedDate = dayjs(date).utc().format('MMMM D, YYYY, h:m A [UTC]')
 
   if (content.formatted) {
     description = content.message

--- a/components/measurement/SummaryText.js
+++ b/components/measurement/SummaryText.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useIntl } from 'react-intl'
 import { Flex, Text } from 'ooni-components'
+import dayjs from 'services/dayjs'
 
 import { getTestMetadata } from '../utils'
 import FormattedMarkdown from '../FormattedMarkdown'
@@ -13,17 +13,8 @@ const SummaryText = ({
   date,
   content,
 }) => {
-  const intl = useIntl()
   const metadata = getTestMetadata(testName)
-  const formattedDateTime = intl.formatDate(date, {
-    year: 'numeric',
-    month: 'long',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: 'numeric',
-    timeZone: 'UTC',
-    timeZoneName: 'short'
-  })
+  const formattedDateTime = dayjs(date).utc().format('MMMM DD, YYYY, hh:mm A [UTC]')
 
   let textToRender = null
   if (typeof content === 'function') {

--- a/components/measurement/SummaryText.js
+++ b/components/measurement/SummaryText.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import moment from 'moment'
 import { useIntl } from 'react-intl'
 import { Flex, Text } from 'ooni-components'
 
@@ -16,7 +15,7 @@ const SummaryText = ({
 }) => {
   const intl = useIntl()
   const metadata = getTestMetadata(testName)
-  const formattedDateTime = intl.formatDate(moment.utc(date).toDate(), {
+  const formattedDateTime = intl.formatDate(date, {
     year: 'numeric',
     month: 'long',
     day: '2-digit',

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -9,7 +9,6 @@ import {
   Text
 } from 'ooni-components'
 
-import moment from 'moment'
 import { Tick, Cross } from 'ooni-components/dist/icons'
 import deepmerge from 'deepmerge'
 import styled from 'styled-components'
@@ -334,7 +333,7 @@ const WebConnectivityDetails = ({
   } = validateMeasurement(measurement ?? {})
 
   const intl = useIntl()
-  const date = intl.formatDate(moment.utc(test_start_time).toDate(), {
+  const date = intl.formatDate(test_start_time, {
     year: 'numeric',
     month: 'long',
     day: '2-digit',

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -314,7 +314,7 @@ const WebConnectivityDetails = ({
   country,
   measurement,
   scores,
-  measurementStartTime,
+  measurement_start_time,
   probe_asn,
   input,
   render
@@ -334,7 +334,7 @@ const WebConnectivityDetails = ({
   } = validateMeasurement(measurement ?? {})
 
   const intl = useIntl()
-  const date = dayjs(measurementStartTime).utc().format('MMMM DD, YYYY, hh:mm A [UTC]')
+  const date = dayjs(measurement_start_time).utc().format('MMMM DD, YYYY, hh:mm A [UTC]')
 
   const p = url.parse(input)
   const hostname = p.host
@@ -621,7 +621,7 @@ WebConnectivityDetails.propTypes = {
       blocking_type: PropTypes.any
     })
   }),
-  measurementStartTime: PropTypes.any
+  measurement_start_time: PropTypes.any
 }
 
 export default WebConnectivityDetails

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -314,7 +314,7 @@ const WebConnectivityDetails = ({
   country,
   measurement,
   scores,
-  test_start_time,
+  measurementStartTime,
   probe_asn,
   input,
   render
@@ -334,7 +334,7 @@ const WebConnectivityDetails = ({
   } = validateMeasurement(measurement ?? {})
 
   const intl = useIntl()
-  const date = dayjs(test_start_time).utc().format('MMMM DD, YYYY, hh:mm A [UTC]')
+  const date = dayjs(measurementStartTime).utc().format('MMMM DD, YYYY, hh:mm A [UTC]')
 
   const p = url.parse(input)
   const hostname = p.host
@@ -621,7 +621,7 @@ WebConnectivityDetails.propTypes = {
       blocking_type: PropTypes.any
     })
   }),
-  test_start_time: PropTypes.any
+  measurementStartTime: PropTypes.any
 }
 
 export default WebConnectivityDetails

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -12,6 +12,7 @@ import {
 import { Tick, Cross } from 'ooni-components/dist/icons'
 import deepmerge from 'deepmerge'
 import styled from 'styled-components'
+import dayjs from 'services/dayjs'
 
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl'
 
@@ -333,15 +334,7 @@ const WebConnectivityDetails = ({
   } = validateMeasurement(measurement ?? {})
 
   const intl = useIntl()
-  const date = intl.formatDate(test_start_time, {
-    year: 'numeric',
-    month: 'long',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: 'numeric',
-    timeZone: 'UTC',
-    timeZoneName: 'short'
-  })
+  const date = dayjs(test_start_time).utc().format('MMMM DD, YYYY, hh:mm A [UTC]')
 
   const p = url.parse(input)
   const hostname = p.host

--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -9,6 +9,7 @@ import {
   Label,
 } from 'ooni-components'
 import moment from 'moment'
+import dayjs from 'services/dayjs'
 import { useForm, Controller } from 'react-hook-form'
 
 import DatePicker from '../DatePicker'
@@ -125,7 +126,7 @@ function isValidFilterForTestname(testName = 'XX', arrayWithMapping) {
 
 // Display `${tomorrow}` as the end date for default search
 // to include the measurements of `${today}` as well.
-const tomorrowUTC = moment.utc().add(1, 'day').format('YYYY-MM-DD')
+const tomorrowUTC = dayjs.utc().add(1, 'day').format('YYYY-MM-DD')
 
 const asnRegEx = /^(AS)?([1-9][0-9]*)$/
 const domainRegEx = /(^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,7}(:[0-9]{1,5})?$)|(^(([0-9]{1,3})\.){3}([0-9]{1,3}))/
@@ -206,7 +207,7 @@ const FilterSidebar = ({
     // Valid dates for start of date range
     // 1. Before the 'Until' date, if provided
     // 2. Until tomorrow
-    const tomorrow = moment.utc().add(1, 'day')
+    const tomorrow = dayjs.utc().add(1, 'day')
     if (untilFilterValue.length !== 0) {
       return currentDate.isBefore(untilFilterValue)
     } else {
@@ -218,7 +219,7 @@ const FilterSidebar = ({
     // Valid dates for end of date range
     // 1. After the 'Since' date if provided
     // 2. Until tomorrow
-    const tomorrow = moment.utc().add(1, 'day')
+    const tomorrow = dayjs.utc().add(1, 'day')
     if (sinceFilterValue.length !== 0) {
       return currentDate.isAfter(sinceFilterValue) && currentDate.isSameOrBefore(tomorrow)
     } else {

--- a/components/search/ResultsList.js
+++ b/components/search/ResultsList.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import url from 'url'
-import moment from 'moment'
+import dayjs from 'services/dayjs'
 import NLink from 'next/link'
 import styled from 'styled-components'
 import { defineMessages, useIntl } from 'react-intl'
@@ -380,7 +380,7 @@ const ResultItem = ({
                   <ASNBox asn={probe_asn} />
                 </Box>
                 <Box width={5/16}>
-                  {moment.utc(measurement_start_time).format('YYYY-MM-DD HH:mm [UTC]')}
+                  {dayjs.utc(measurement_start_time).format('YYYY-MM-DD HH:mm [UTC]')}
                 </Box>
                 <Box width={5/16}>
                   {testDisplayName}

--- a/cypress/integration/measurement.e2e.js
+++ b/cypress/integration/measurement.e2e.js
@@ -10,19 +10,19 @@ describe('Measurement Page Tests', () => {
     it('renders a valid accessible og:description', () => {
       cy.visit('/measurement/20200807T220702Z_AS9009_VDIirQFXzvVZXGTDXrRKAd7oQB3CpnKGISOZLs7kQFV6RJNR7n?input=https%3A%2F%2Fwww.theguardian.com%2F')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests www.theguardian.com was accessible in United States on August 7, 2020, 10:42:51 PM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests www.theguardian.com was accessible in United States on August 7, 2020, 10:44:09 PM UTC, find more open data on internet censorship on OONI Explorer.')
     })
 
     it('renders a valid blocked og:description', () => {
       cy.visit('/measurement/20200303T085244Z_AS42668_UThI3Fdoo0IZ6610604dd0CGkhd7oQV6QLWWzZDVLJ35oGxBO4?input=http%3A%2F%2Frutor.org%2F')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests rutor.org was blocked in Russia on March 3, 2020, 8:52:44 AM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests rutor.org was blocked in Russia on March 3, 2020, 9:15:05 AM UTC, find more open data on internet censorship on OONI Explorer.')
     })
 
     it('renders a valid anomaly og:description', () => {
       cy.visit('/measurement/20200807T223513Z_AS27364_QJdsvFRG6B98MqqWR3QTey9WheksI7757sefWWMwAe0OHU8hWT?input=http%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dlesbian')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests www.google.com was accessible in United States on August 7, 2020, 10:35:09 PM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests www.google.com was accessible in United States on August 7, 2020, 10:36:29 PM UTC, find more open data on internet censorship on OONI Explorer.')
     })
 
     // it('renders a valid website down og:description', () => {
@@ -70,13 +70,13 @@ describe('Measurement Page Tests', () => {
     it('renders a reachable og:description', () => {
       cy.visit('/measurement/20200807T220134Z_AS9009_SOmXTa7NLwrzRniaVS0yxlJ3TbKTDJJxrfaIJkpURTn3GBHiA2')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests Telegram was reachable in United States on August 7, 2020, 10:37:27 PM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests Telegram was reachable in United States on August 7, 2020, 10:37:28 PM UTC, find more open data on internet censorship on OONI Explorer.')
     })
 
     it('renders a unreachable og:description', () => {
       cy.visit('/measurement/20200304T183801Z_AS42610_uehNyFJgkAJBCaq5thzAovFEODIQ1u5vlTTk3D6GDvbaYeoJY8')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests Telegram was NOT reachable in Russia on March 4, 2020, 6:37:57 PM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests Telegram was NOT reachable in Russia on March 4, 2020, 6:57:54 PM UTC, find more open data on internet censorship on OONI Explorer.')
     })
 
     it('renders an accessible measurement', () => {
@@ -102,7 +102,7 @@ describe('Measurement Page Tests', () => {
     it('renders an unreachable og:description', () => {
       cy.visit('/measurement/20200407T024309Z_AS4713_xA9Wh81DQrIFqRe46zwKeyJw4DJQwjyTLBIi2zSQqWUBsfQMJS')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests WhatsApp was likely blocked in Japan on April 7, 2020, 2:43:06 AM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests WhatsApp was likely blocked in Japan on April 7, 2020, 2:43:10 AM UTC, find more open data on internet censorship on OONI Explorer.')
     })
 
     it('renders an accessible measurement', () => {
@@ -165,7 +165,7 @@ describe('Measurement Page Tests', () => {
     it('renders a unreachable og:description', () => {
       cy.visit('/measurement/20200304T191012Z_AS42610_fqDY31xiRoWEdKd4GWtV84UYpXG2RlpjBK7kd8rTLHIItqMnej')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests Facebook Messenger was NOT reachable in Russia on March 4, 2020, 5:52:38 AM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests Facebook Messenger was NOT reachable in Russia on March 4, 2020, 6:37:43 PM UTC, find more open data on internet censorship on OONI Explorer.')
     })
   })
 
@@ -188,7 +188,7 @@ describe('Measurement Page Tests', () => {
     it('renders an anomaly og:description', () => {
       cy.visit('/measurement/20190530T141520Z_AS4788_DNqCUqL7CAfijExowyaymigb2sITdpS47gjrieDJCx8kDc1TfO')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests HTTP header manipulation was detected in Malaysia on May 30, 2019, 2:15:15 PM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests HTTP header manipulation was detected in Malaysia on May 30, 2019, 2:15:19 PM UTC, find more open data on internet censorship on OONI Explorer.')
     })
   })
 
@@ -211,7 +211,7 @@ describe('Measurement Page Tests', () => {
     it('render an anomaly og:description', () => {
       cy.visit('/measurement/20170213T160709Z_AS8452_M5qSjOZgYwFrkQYVfdrYmYw2tLc3dzJB7mVbtjVoR1qCdbcEOA')
       cy.get('head meta[property="og:description"]')
-        .should('have.attr', 'content', 'OONI data suggests Network traffic manipulation was detected in Egypt on February 13, 2017, 4:06:58 PM UTC, find more open data on internet censorship on OONI Explorer.')
+        .should('have.attr', 'content', 'OONI data suggests Network traffic manipulation was detected in Egypt on February 13, 2017, 4:07:00 PM UTC, find more open data on internet censorship on OONI Explorer.')
     })
   })
 

--- a/cypress/integration/search.e2e.js
+++ b/cypress/integration/search.e2e.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import dayjs from '../../services/dayjs'
 
 describe('Seearch Page Tests', () => {
 
@@ -55,18 +55,18 @@ describe('Seearch Page Tests', () => {
         cy.wrap($firstRow).contains(/31|30|29|28/).click()
       })
     cy.get('#since-filter').should(($sinceDate) => {
-      const firstOfMonth = moment().startOf('month')
+      const firstOfMonth = dayjs().startOf('month')
       const selectedSinceDate = $sinceDate.val()
-      expect(firstOfMonth.isAfter(selectedSinceDate)).to.be.true
+      expect(dayjs(firstOfMonth).isAfter(selectedSinceDate)).to.be.true
     })
 
     // click in the until date filter and select a day before today
     cy.get('#until-filter').click()
     cy.get('.rdt.rdtOpen .rdtToday').click()
     cy.get('#until-filter').should(($untilDate) => {
-      const firstOfMonth = moment().startOf('month')
+      const firstOfMonth = dayjs().startOf('month')
       const selectedUntilDate = $untilDate.val()
-      expect(firstOfMonth.isSameOrBefore(selectedUntilDate)).to.be.true
+      expect(dayjs(firstOfMonth).isSameOrBefore(selectedUntilDate)).to.be.true
     })
 
     cy.get('[data-test-id="testname-filter"]').select('Telegram')

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-plugin-styled-components": "^1.10.7",
     "buffer-from": "^1.1.1",
     "country-util": "0.1.0",
+    "dayjs": "^1.10.8",
     "deepmerge": "^4.2.2",
     "flag-icon-css": "^2.9.0",
     "fontsource-fira-sans": "^3.0.5",

--- a/pages/experimental/website/index.js
+++ b/pages/experimental/website/index.js
@@ -4,8 +4,8 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { Container, Flex, Box } from 'ooni-components'
 import useSWR from 'swr'
-import moment from 'moment'
 import axios from 'axios'
+import dayjs from 'services/dayjs'
 
 import Layout from '../../../components/Layout'
 import NavBar from '../../../components/NavBar'
@@ -29,8 +29,8 @@ const dataFetcher = url => (
 )
 
 const defaultParams = {
-  'since': moment.utc().subtract(1, 'months').format('YYYY-MM-DD'),
-  'until': moment.utc().format('YYYY-MM-DD'),
+  'since': dayjs.utc().subtract(1, 'month').format('YYYY-MM-DD'),
+  'until': dayjs.utc().format('YYYY-MM-DD'),
   'axis_x': 'probe_cc',
   'test_name': 'web_connectivity',
   'input': 'thepiratebay.org',

--- a/pages/measurement/[[...report_id]].js
+++ b/pages/measurement/[[...report_id]].js
@@ -111,7 +111,7 @@ const Measurement = ({
   anomaly,
   failure,
   test_name,
-  test_start_time,
+  measurement_start_time,
   probe_cc,
   probe_asn,
   notFound = false,
@@ -147,7 +147,7 @@ const Measurement = ({
           country={country}
           measurement={raw_measurement}
           input={input}
-          test_start_time={test_start_time}
+          measurementStartTime={measurement_start_time}
           probe_asn={probe_asn}
           scores={scores}
           {...rest}
@@ -172,7 +172,7 @@ const Measurement = ({
                     testName={test_name}
                     testUrl={input}
                     country={country}
-                    date={test_start_time}
+                    date={measurement_start_time}
                   />
                 }
                 <NavBar color={color} />
@@ -184,7 +184,7 @@ const Measurement = ({
                   info={info}
                 />
                 <CommonSummary
-                  test_start_time={test_start_time}
+                  measurementStartTime={measurement_start_time}
                   probe_asn={probe_asn}
                   probe_cc={probe_cc}
                   color={color}
@@ -204,7 +204,7 @@ const Measurement = ({
                       testUrl={input}
                       network={probe_asn}
                       country={country}
-                      date={test_start_time}
+                      date={measurement_start_time}
                       content={summaryText}
                     />
                   }
@@ -235,7 +235,7 @@ Measurement.propTypes = {
   raw_measurement: PropTypes.object,
   report_id: PropTypes.string,
   test_name: PropTypes.string,
-  test_start_time: PropTypes.string
+  measurement_start_time: PropTypes.string
 }
 
 export default Measurement

--- a/pages/measurement/[[...report_id]].js
+++ b/pages/measurement/[[...report_id]].js
@@ -147,7 +147,7 @@ const Measurement = ({
           country={country}
           measurement={raw_measurement}
           input={input}
-          measurementStartTime={measurement_start_time}
+          measurement_start_time={measurement_start_time}
           probe_asn={probe_asn}
           scores={scores}
           {...rest}
@@ -184,7 +184,7 @@ const Measurement = ({
                   info={info}
                 />
                 <CommonSummary
-                  measurementStartTime={measurement_start_time}
+                  measurement_start_time={measurement_start_time}
                   probe_asn={probe_asn}
                   probe_cc={probe_cc}
                   color={color}

--- a/pages/search.js
+++ b/pages/search.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Head from 'next/head'
 import { withRouter } from 'next/router'
-import moment from 'moment'
 import axios from 'axios'
 import styled from 'styled-components'
 import {
@@ -13,6 +12,7 @@ import {
   Text
 } from 'ooni-components'
 import { FormattedMessage } from 'react-intl'
+import dayjs from 'services/dayjs'
 
 import NavBar from '../components/NavBar'
 import Layout from '../components/Layout'
@@ -152,12 +152,12 @@ class Search extends React.Component {
     // including the measurements of today (so the date of tomorrow).
     // This prevents the search page from showing time-travelling future
     // measurements from showing up
-    const since = moment(query.until).utc().subtract(30, 'day').format('YYYY-MM-DD')
+    const since = dayjs(query.until).utc().subtract(30, 'day').format('YYYY-MM-DD')
     if (!query.since) {
       query.since = since
     }
 
-    const until = moment.utc().add(1, 'day').format('YYYY-MM-DD')
+    const until = dayjs.utc().add(1, 'day').format('YYYY-MM-DD')
     if ('until' in query === false) {
       query.until = until
     }

--- a/services/dayjs.js
+++ b/services/dayjs.js
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+
+dayjs
+  .extend(utc)
+  .extend(relativeTime)
+  .extend(isSameOrBefore)
+
+export default dayjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,6 +2449,11 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
   integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
 
+dayjs@^1.10.8:
+  version "1.10.8"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.8.tgz#267df4bc6276fcb33c04a6735287e3f429abec41"
+  integrity sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==
+
 debug@2, debug@^2.1.2, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Related issue: https://github.com/ooni/explorer/issues/510

Also fixes an issue with inconsistent time display - described in: https://github.com/ooni/explorer/issues/515

Initially, I intended to go with date-fns, but unfortunately it doesn't have a nice interface to work with timezones/utc and it required working a lot with the native Date object, which defeats the purpose of a library altogether. After a bit of exploration and testing, I decided to go with day.js, which is very lightweight, just as popular, and with a very similar interface as momentjs - which makes it also easy to replace.

Unfortunately, it's not possible to get rid of moment.js completely just yet since the `Datetime` component depends on it. I will follow up with [this issue](https://github.com/ooni/explorer/issues/689), to replace it with a date-library-agnostic component and remove the use of momentjs completely in another PR.