### PR TITLE
Set different defaults to env vars in prod/dev/test envs

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
-NEXT_PUBLIC_MEASUREMENTS_URL=https://api.ooni.io
-NEXT_PUBLIC_AGGREGATION_API=https://api.ooni.io
-NEXT_PUBLIC_EXPLORER_URL=https://explorer.ooni.org
+# Variables common to all environments
+# To override locally, make a copy called `.env.local` (which is not loaded when NODE_ENV=test.)
+# Refer: https://nextjs.org/docs/basic-features/environment-variables
+
 PORT=3100

--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,7 @@
-# Used in test/CI environemnts
-# To override locally, make a copy called `.env.test.local`
+# Used only in development environments
+# To override locally, make a copy called `.env.development.local`
 # Refer: https://nextjs.org/docs/basic-features/environment-variables
 
 NEXT_PUBLIC_MEASUREMENTS_URL=https://ams-pg-test.ooni.org
-NEXT_PUBLIC_EXPLORER_URL=https://explorer-test.ooni.io
 NEXT_PUBLIC_AGGREGATION_API=https://backend-fsn.ooni.org
+NEXT_PUBLIC_EXPLORER_URL=http://localhost:3100

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,7 @@
+# Used only in producition 
+# To override locally, make a copy called `.env.production.local`
+# Refer: https://nextjs.org/docs/basic-features/environment-variables
+
 NEXT_PUBLIC_MEASUREMENTS_URL=https://api.ooni.io
 NEXT_PUBLIC_AGGREGATION_API=https://backend-fsn.ooni.org
 NEXT_PUBLIC_SENTRY_DSN=https://49af7fff247c445b9a7c98ee21ddfd2f@o155150.ingest.sentry.io/1427510


### PR DESCRIPTION
Separate defaults for env variables in different environments.
This allows new devs to use test instance of API for local development out of the box. ﻿
