### PR TITLE
lazy loading the country images

### DIFF
--- a/components/Flag.js
+++ b/components/Flag.js
@@ -48,7 +48,7 @@ export const Flag = ({countryCode, size, border}) => {
   const src = `/static/flags/1x1/${countryCode}.svg`
   return (
     <FlagContainer className='country-flag' size={size} border={border}>
-      <FlagImg src={src} size={size} />
+      <FlagImg src={src} size={size} loading='lazy' />
     </FlagContainer>
   )
 }


### PR DESCRIPTION
Current case -

https://user-images.githubusercontent.com/32815509/158387128-9fb7ad14-77bd-4ff9-b065-07e58a53075d.mp4

It is loading every country image at the time of page load, I think creating too much pressure on the main javascript thread. How about showing images only after we scroll?

New lazy loading case - 

https://user-images.githubusercontent.com/32815509/158387324-f6350bbf-1293-4d51-8c62-163906edc37e.mp4


