### PR TITLE
Show country-wise data for twitter.com when MAT opens from NavBar

### DIFF
--- a/components/aggregation/mat/Form.js
+++ b/components/aggregation/mat/Form.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useForm, Controller } from 'react-hook-form'
 import styled from 'styled-components'
@@ -92,13 +92,26 @@ const defaultDefaultValues = {
 }
 
 export const Form = ({ onSubmit, testNames, query }) => {
+  const isInitialMount = useRef(true)
   const intl = useIntl()
   const [showConfirmation, setShowConfirmation] = useState(false)
 
   const defaultValues = Object.assign({}, defaultDefaultValues, query)
-  const { handleSubmit, control, getValues, watch } = useForm({
+  const { handleSubmit, control, getValues, watch, reset } = useForm({
     defaultValues
   })
+
+  // If `query` changes after the page mounts, reset the form to use default
+  // values based on new `query`
+  useEffect(() => {
+    // Skip running this on mount to avoid unnecessary re-renders
+    // Based on: https://reactjs.org/docs/hooks-faq.html#can-i-run-an-effect-only-on-updates
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+    } else {
+      reset(query)
+    }
+  }, [reset, query])
 
   const sortedCountries = countryList
     .sort((a,b) => (a.iso3166_name < b.iso3166_name) ? -1 : (a.iso3166_name > b.iso3166_name) ? 1 : 0)

--- a/pages/chart/mat.js
+++ b/pages/chart/mat.js
@@ -90,9 +90,7 @@ const MeasurementAggregationToolkit = ({ testNames }) => {
         pathname: router.pathname,
         query: {
           test_name: 'web_connectivity',
-          domain: 'twitter.com',
           axis_x: 'measurement_start_day',
-          axis_y: 'probe_cc',
           since: monthAgo.format('YYYY-MM-DD'),
           until: today.format('YYYY-MM-DD'),
         },

--- a/pages/chart/mat.js
+++ b/pages/chart/mat.js
@@ -79,7 +79,9 @@ const MeasurementAggregationToolkit = ({ testNames }) => {
 
   }, [router])
 
-  React.useEffect(() => {
+  // Upon mount, check if the page was accessed without query params
+  // In that case, trigger a shallow navigation that shows a chart
+  useEffect(() => {
     const { query } = router
     if (Object.keys(query).length === 0) {
       const today = dayjs.utc().add(1, 'day')
@@ -88,9 +90,9 @@ const MeasurementAggregationToolkit = ({ testNames }) => {
         pathname: router.pathname,
         query: {
           test_name: 'web_connectivity',
-          // domain: 'twitter.com',
+          domain: 'twitter.com',
           axis_x: 'measurement_start_day',
-          // axis_y: 'probe_cc',
+          axis_y: 'probe_cc',
           since: monthAgo.format('YYYY-MM-DD'),
           until: today.format('YYYY-MM-DD'),
         },


### PR DESCRIPTION
This sets the default chart shown on `/chart/mat` to "country-wise daily-counts for `twitter.com` in last 30 days"
