### PR TITLE
Serialize search page errors in SSR

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -188,12 +188,7 @@ class Search extends React.Component {
     try {
       msmtR = await getMeasurements(query)
     } catch (err) {
-      let error
-      if (err.response) {
-        error = err.response.data
-      } else {
-        error = err.message
-      }
+      const error = serializeError(err)
       return {
         error,
         results: [],


### PR DESCRIPTION
Fixes situations where API query errors out in the SSR phase. We reuse the `serializeError` function that already generates a useful error object that is rendered consistently on the page when API queries fail client-side (e.g after clicking the `Filter Results` or `Load More` buttons). 