### PR TITLE
Fix text on WhatsApp measurement page when it's blocked

### DIFF
--- a/components/measurement/nettests/WhatsApp.js
+++ b/components/measurement/nettests/WhatsApp.js
@@ -21,8 +21,10 @@ const BugBox = styled(Box)`
   padding: 20px;
 `
 
-const WhatsAppDetails = ({ isAnomaly, scores, measurement, render }) => {
+const WhatsAppDetails = ({ scores, measurement, render }) => {
   const testKeys = measurement.test_keys
+  const isAnomaly = testKeys.whatsapp_web_status === 'blocked'
+
   const tcp_connect = testKeys.tcp_connect
   let registrationServerAccessible, webAccessible, endpointsAccessible
   try {


### PR DESCRIPTION
I used a similar logic to how determining anomaly is done for Signal and some other messaging components, the rest seems to work correctly now. 

Closes https://github.com/ooni/explorer/issues/660