### PR TITLE
Fix: reset domain filter when switching test names

### DIFF
--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -151,7 +151,7 @@ const FilterSidebar = ({
     hideFailed
   }
 
-  const { handleSubmit, control, watch, resetField, formState } = useForm({
+  const { handleSubmit, control, watch, resetField, formState, setValue } = useForm({
     defaultValues
   })
   const { errors } = formState
@@ -166,8 +166,8 @@ const FilterSidebar = ({
   const showDomain = useMemo(() => isValidFilterForTestname(testNameFilterValue, testsWithValidDomain), [testNameFilterValue])
   // to avoid bad queries, blank out the `domain` field when it is shown/hidden
   useEffect(() => {
-    resetField('domainFilter')
-  }, [resetField, showDomain])
+    setValue('domainFilter', '')
+  }, [setValue, showDomain])
 
   // Can we filter out anomalies or confirmed for this test_name
   const showAnomalyFilter = useMemo(() => isValidFilterForTestname(testNameFilterValue, testsWithAnomalyStatus), [testNameFilterValue])


### PR DESCRIPTION
Fixed by setting domainFilter to empty string instead of "resetting", since it might have a value by default.

Closes https://github.com/ooni/explorer/issues/735