### PR TITLE
Fixed country search display message while no country was found

### DIFF
--- a/pages/countries.js
+++ b/pages/countries.js
@@ -145,7 +145,7 @@ const NoCountriesFound = ({ searchTerm }) => (
         {/* TODO Add to copy */}
         <FormattedMessage
           id='Countries.Search.NoCountriesFound'
-          values={{ searchTerm }}
+          values={ searchTerm }
         />
       </Text>
     </Box>


### PR DESCRIPTION
Fixes #792

- [x] Removed extra pair of curly braces around the "searchTerm" in countries page 