### PR TITLE
Add links to search in MAT tooltip for all counts

### DIFF
--- a/components/aggregation/mat/CustomTooltip.js
+++ b/components/aggregation/mat/CustomTooltip.js
@@ -46,7 +46,15 @@ export const generateSearchQuery = (data, query) => {
     untilFilter = untilPlus1.toISOString().split('T')[0]
   }
 
-  const queryObj = ['probe_cc', 'test_name', 'category_code', 'probe_asn', 'input', 'domain'].reduce((q, k) => {
+  const queryObj = [
+    'probe_cc',
+    'test_name',
+    'category_code',
+    'probe_asn',
+    'input',
+    'domain',
+    'only',
+    'failure'].reduce((q, k) => {
     if (k in data)
       q[k] = data[k]
     else if (query[k])
@@ -68,12 +76,30 @@ export const generateSearchQuery = (data, query) => {
   }
 }
 
+const getDataKeyLink = (data, matQuery, keyQuery) => {
+  const mergeQuery = {...matQuery, ...keyQuery}
+  const query = generateSearchQuery(data, mergeQuery)
+  
+  return {
+    pathname: '/search',
+    query
+  }
+}
+
 const CustomToolTip = React.memo(({ data, onClose, title, link = true }) => {
   const theme = useTheme()
   const intl = useIntl()
   const [query] = useMATContext()
-  const dataKeysToShow = ['anomaly_count', 'confirmed_count', 'failure_count', 'ok_count']
 
+  const dataKeysToShow = useMemo(() => {
+    return {
+      'anomaly_count': getDataKeyLink(data, query, {only: 'anomalies'}),
+      'confirmed_count': getDataKeyLink(data, query, {only: 'confirmed'}),
+      'failure_count': getDataKeyLink(data, query, {failure: true}),
+      'ok_count': getDataKeyLink(data, query)
+    }
+  }, [data, query])
+  
   const [linkToMeasurements, derivedTitle] = useMemo(() => {
     const searchQuery = generateSearchQuery(data, query)
     const linkObj = {
@@ -97,12 +123,16 @@ const CustomToolTip = React.memo(({ data, onClose, title, link = true }) => {
         <MdClear title='Close' strokeWidth={2} onClick={onClose} />
       </Flex>
       <Flex flexDirection='column' pr={3} my={1}>
-        {dataKeysToShow.map(k => (
+        {Object.entries(dataKeysToShow).map(([k, v]) => (
           <Box key={k} my={1} fontSize={16}>
             <Flex alignItems='center'>
               <Box mr={3}><Chip color={colorMap[k]} /></Box>
-              <Text mr={4}>{k}</Text>
-              <Text ml='auto'>{intl.formatNumber(Number(data[k] ?? 0))}</Text>
+              <NLink passHref href={v}>
+                <Link target='_blank'>
+                  <Text mr={4}>{k}</Text>
+                </Link>
+              </NLink>
+                <Text ml='auto'>{intl.formatNumber(Number(data[k] ?? 0))}</Text>
             </Flex>
           </Box>
         ))}


### PR DESCRIPTION
There are API changes needed to show only `failure_count` or `ok_count`.

Closes https://github.com/ooni/explorer/issues/802