### PR TITLE
DNS Answers: Add columns for AS number and ISP name

### DIFF
--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -175,7 +175,7 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
-const FiveColRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
+const DNSAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
       <DnsAnswerCell>{name}</DnsAnswerCell>
@@ -187,7 +187,7 @@ const FiveColRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Ty
   </Text>
 )
 
-FiveColRow.propTypes = {
+DNSAnswerRow.propTypes = {
   name: PropTypes.string,
   netClass: PropTypes.string,
   ttl: PropTypes.number,
@@ -228,9 +228,9 @@ const QueryContainer = ({query}) => {
       {failure && <Box width={1}><FailureString failure={failure} /></Box>}
       {!failure &&
         <Box width={1}>
-          <FiveColRow header />
+          <DNSAnswerRow header />
           {Array.isArray(answers) && answers.map((dnsAnswer, index) => (
-            <FiveColRow
+            <DNSAnswerRow
               key={index}
               name='@'
               netClass='IN'

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -175,7 +175,9 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
-const DNSAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
+const DNSAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type',
+                        data = 'DATA', asn = 'ASN', as_org_name = 'ISP',
+                        header = false}) => (
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
       <DnsAnswerCell>{name}</DnsAnswerCell>
@@ -183,6 +185,8 @@ const DNSAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = '
       <DnsAnswerCell>{ttl}</DnsAnswerCell>
       <DnsAnswerCell>{type}</DnsAnswerCell>
       <DnsAnswerCell>{data}</DnsAnswerCell>
+      <DnsAnswerCell>{asn}</DnsAnswerCell>
+      <DnsAnswerCell>{as_org_name}</DnsAnswerCell>
     </Flex>
   </Text>
 )
@@ -193,6 +197,8 @@ DNSAnswerRow.propTypes = {
   ttl: PropTypes.number,
   type: PropTypes.string,
   data: PropTypes.string,
+  asn: PropTypes.number,
+  as_org_name: PropTypes.string,
   header: PropTypes.bool
 }
 
@@ -244,6 +250,8 @@ const QueryContainer = ({query}) => {
                     ? dnsAnswer.hostname
                     : null // for any other answer_type, DATA column will be empty
               }
+              asn={dnsAnswer.asn || null}
+              as_org_name={dnsAnswer.as_org_name || null}
             />
           ))}
         </Box>


### PR DESCRIPTION
The measurement JSON may include additional information about IP
addresses returned in DNS answers.  In particular, the "asn" field
contains the AS (Autonomous System) number advertising the IP address,
and "as_org_name" the organizational name for that AS/ISP.
    
This change adds these fields to the answer table as two additional
columns.

I'm not sure this is the best way to present this information, but it
fulfils the feature request and works even when the additional fields
are missing.  In this case the values in the new columns will simply
be empty.

Closes #821
