### PR TITLE
DNS Answers: Add ancillary information

### DIFF
--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -179,7 +179,7 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
-const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', anc = 'Ancillary info', header = false}) => (
+const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', answer_ip_info = 'Answer IP Info', header = false}) => (
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
       <DnsAnswerCell>{name}</DnsAnswerCell>
@@ -187,7 +187,7 @@ const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = '
       <DnsNarrowAnswerCell>{ttl}</DnsNarrowAnswerCell>
       <DnsNarrowAnswerCell>{type}</DnsNarrowAnswerCell>
       <DnsAnswerCell>{data}</DnsAnswerCell>
-      <DnsAnswerCell>{anc}</DnsAnswerCell>
+      <DnsAnswerCell>{answer_ip_info}</DnsAnswerCell>
     </Flex>
   </Text>
 )
@@ -198,7 +198,7 @@ DnsAnswerRow.propTypes = {
   ttl: PropTypes.number,
   type: PropTypes.string,
   data: PropTypes.string,
-  anc: PropTypes.string,
+  answer_ip_info: PropTypes.string,
   header: PropTypes.bool
 }
 
@@ -250,12 +250,12 @@ const QueryContainer = ({query}) => {
                     ? dnsAnswer.hostname
                     : null // for any other answer_type, DATA column will be empty
               }
-              anc={dnsAnswer.asn
-                   ? dnsAnswer.as_org_name
-                     ? `AS${dnsAnswer.asn} (${dnsAnswer.as_org_name})`
-                     : `AS${dnsAnswer.asn}`
-                   : dnsAnswer.as_org_name
-                   ? `AS??? (${dnsAnswer.as_org_name})` : null}
+              answer_ip_info={dnsAnswer.asn
+                              ? dnsAnswer.as_org_name
+                              ? `AS${dnsAnswer.asn} (${dnsAnswer.as_org_name})`
+                              : `AS${dnsAnswer.asn}`
+                              : dnsAnswer.as_org_name
+                              ? `Unknown AS (${dnsAnswer.as_org_name})` : null}
             />
           ))}
         </Box>

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -179,6 +179,16 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
+const DnsAnswerIpInfo = (dnsAnswer) => {
+    return dnsAnswer.asn
+        ? dnsAnswer.as_org_name
+        ? `AS${dnsAnswer.asn} (${dnsAnswer.as_org_name})`
+        : `AS${dnsAnswer.asn}`
+    : dnsAnswer.as_org_name
+        ? `Unknown AS (${dnsAnswer.as_org_name})`
+        : null
+}
+
 const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', answer_ip_info = 'Answer IP Info', header = false}) => (
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
@@ -250,12 +260,7 @@ const QueryContainer = ({query}) => {
                     ? dnsAnswer.hostname
                     : null // for any other answer_type, DATA column will be empty
               }
-              answer_ip_info={dnsAnswer.asn
-                              ? dnsAnswer.as_org_name
-                              ? `AS${dnsAnswer.asn} (${dnsAnswer.as_org_name})`
-                              : `AS${dnsAnswer.asn}`
-                              : dnsAnswer.as_org_name
-                              ? `Unknown AS (${dnsAnswer.as_org_name})` : null}
+              answer_ip_info={DnsAnswerIpInfo(dnsAnswer)}
             />
           ))}
         </Box>

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -167,8 +167,12 @@ FailureString.propTypes = {
   failure: PropTypes.string
 }
 
+const DnsNarrowAnswerCell = (props) => (
+  <Box width={1/12}>{props.children}</Box>
+)
+
 const DnsAnswerCell = (props) => (
-  <Box width={1/8}>{props.children}</Box>
+  <Box width={1/4}>{props.children}</Box>
 )
 
 DnsAnswerCell.propTypes = {
@@ -179,9 +183,9 @@ const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = '
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
       <DnsAnswerCell>{name}</DnsAnswerCell>
-      <DnsAnswerCell>{netClass}</DnsAnswerCell>
-      <DnsAnswerCell>{ttl}</DnsAnswerCell>
-      <DnsAnswerCell>{type}</DnsAnswerCell>
+      <DnsNarrowAnswerCell>{netClass}</DnsNarrowAnswerCell>
+      <DnsNarrowAnswerCell>{ttl}</DnsNarrowAnswerCell>
+      <DnsNarrowAnswerCell>{type}</DnsNarrowAnswerCell>
       <DnsAnswerCell>{data}</DnsAnswerCell>
       <DnsAnswerCell>{anc}</DnsAnswerCell>
     </Flex>

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -175,7 +175,7 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
-const FiveColRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
+const DNSAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
       <DnsAnswerCell>{name}</DnsAnswerCell>
@@ -187,7 +187,7 @@ const FiveColRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Ty
   </Text>
 )
 
-FiveColRow.propTypes = {
+DNSAnswerRow.propTypes = {
   name: PropTypes.string,
   netClass: PropTypes.string,
   ttl: PropTypes.number,
@@ -228,9 +228,9 @@ const QueryContainer = ({query}) => {
       {failure && <Box width={1}><FailureString failure={failure} /></Box>}
       {!failure &&
         <Box width={1}>
-          <FiveColRow header />
+          <DNSAnswerRow header />
           {Array.isArray(answers) && answers.map((dnsAnswer, index) => (
-            <FiveColRow
+            <DNSAnswerRow
               key={index}
               name='@'
               netClass='IN'

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -175,7 +175,7 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
-const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
+const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', anc = 'Ancillary info', header = false}) => (
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
       <DnsAnswerCell>{name}</DnsAnswerCell>
@@ -183,6 +183,7 @@ const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = '
       <DnsAnswerCell>{ttl}</DnsAnswerCell>
       <DnsAnswerCell>{type}</DnsAnswerCell>
       <DnsAnswerCell>{data}</DnsAnswerCell>
+      <DnsAnswerCell>{anc}</DnsAnswerCell>
     </Flex>
   </Text>
 )
@@ -193,6 +194,7 @@ DnsAnswerRow.propTypes = {
   ttl: PropTypes.number,
   type: PropTypes.string,
   data: PropTypes.string,
+  anc: PropTypes.string,
   header: PropTypes.bool
 }
 
@@ -244,6 +246,12 @@ const QueryContainer = ({query}) => {
                     ? dnsAnswer.hostname
                     : null // for any other answer_type, DATA column will be empty
               }
+              anc={dnsAnswer.asn
+                   ? dnsAnswer.as_org_name
+                     ? `AS${dnsAnswer.asn} (${dnsAnswer.as_org_name})`
+                     : `AS${dnsAnswer.asn}`
+                   : dnsAnswer.as_org_name
+                   ? `AS??? (${dnsAnswer.as_org_name})` : null}
             />
           ))}
         </Box>

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -175,7 +175,7 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
-const DNSAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
+const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', header = false}) => (
   <Text fontWeight={header ? 'bold' : undefined}>
     <Flex flexWrap='wrap' mb={2}>
       <DnsAnswerCell>{name}</DnsAnswerCell>
@@ -187,7 +187,7 @@ const DNSAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = '
   </Text>
 )
 
-DNSAnswerRow.propTypes = {
+DnsAnswerRow.propTypes = {
   name: PropTypes.string,
   netClass: PropTypes.string,
   ttl: PropTypes.number,
@@ -228,9 +228,9 @@ const QueryContainer = ({query}) => {
       {failure && <Box width={1}><FailureString failure={failure} /></Box>}
       {!failure &&
         <Box width={1}>
-          <DNSAnswerRow header />
+          <DnsAnswerRow header />
           {Array.isArray(answers) && answers.map((dnsAnswer, index) => (
-            <DNSAnswerRow
+            <DnsAnswerRow
               key={index}
               name='@'
               netClass='IN'

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -180,13 +180,10 @@ DnsAnswerCell.propTypes = {
 }
 
 const dnsAnswerIpInfo = (dnsAnswer) => {
-    return dnsAnswer.asn
-        ? dnsAnswer.as_org_name
-        ? `AS${dnsAnswer.asn} (${dnsAnswer.as_org_name})`
-        : `AS${dnsAnswer.asn}`
-    : dnsAnswer.as_org_name
-        ? `Unknown AS (${dnsAnswer.as_org_name})`
-        : null
+    const asn = dnsAnswer.asn ? `AS${dnsAnswer.asn}` : 'Unknown AS'
+    const asOrgName = dnsAnswer.as_org_name ? `(${dnsAnswer.as_org_name})` : ''
+
+    return `${asn} ${asOrgName}`.trim()
 }
 
 const DnsAnswerRow = ({ name = 'Name', netClass = 'Class', ttl = 'TTL', type = 'Type', data = 'DATA', answer_ip_info = 'Answer IP Info', header = false}) => (

--- a/components/measurement/nettests/WebConnectivity.js
+++ b/components/measurement/nettests/WebConnectivity.js
@@ -179,7 +179,7 @@ DnsAnswerCell.propTypes = {
   children: PropTypes.any
 }
 
-const DnsAnswerIpInfo = (dnsAnswer) => {
+const dnsAnswerIpInfo = (dnsAnswer) => {
     return dnsAnswer.asn
         ? dnsAnswer.as_org_name
         ? `AS${dnsAnswer.asn} (${dnsAnswer.as_org_name})`
@@ -260,7 +260,7 @@ const QueryContainer = ({query}) => {
                     ? dnsAnswer.hostname
                     : null // for any other answer_type, DATA column will be empty
               }
-              answer_ip_info={DnsAnswerIpInfo(dnsAnswer)}
+              answer_ip_info={dnsAnswerIpInfo(dnsAnswer)}
             />
           ))}
         </Box>


### PR DESCRIPTION
We add a new column to the table of DNS Answers.  This is currently used to present ASN and (ISP) organization name where present.  In order to improve readability, some columns (TTL, type, class) where made narrower.

Fixes #821 