### PR TITLE
undefined check for map array fn

### DIFF
--- a/components/aggregation/mat/Form.js
+++ b/components/aggregation/mat/Form.js
@@ -311,7 +311,7 @@ export const Form = ({ onSubmit, testNames, query }) => {
             control={control}
             render={({field}) => (
               <Select {...field} width={1}>
-                {timeGrainOptions.map((option, idx) => (
+                {timeGrainOptions?.map((option, idx) => (
                   <option key={idx} value={option}>{intl.formatMessage(messages[option])}</option>
                 ))}
               </Select>


### PR DESCRIPTION
Fixes #840 

@hellais  It'll make the time granularity list empty in case of invalid date (year in bug)