### PR TITLE
Setup Prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,6 @@
 {
   "plugins": ["cypress"],
-  "extends": [
-    "next/core-web-vitals",
-    "plugin:cypress/recommended"
-  ],
-  "rules": {
-    "linebreak-style": ["error", "unix"],
-    "quotes": ["error", "single"],
-    "semi": ["error", "never"]
-  },
+  "extends": ["next/core-web-vitals", "plugin:cypress/recommended", "prettier"],
+  "rules": {},
   "ignorePatterns": ["components/vendor", "static"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+.next
+build

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "endOfLine": "lf",
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "cypress-recurse": "^1.27.0",
     "eslint": "^8.22.0",
     "eslint-config-next": "^12.2.5",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-cypress": "^2.12.1",
     "glob": "^8.0.3",
     "imap-simple": "^5.1.0",
@@ -80,6 +81,7 @@
     "mailparser": "^3.6.3",
     "mustache": "^4.2.0",
     "nodemailer": "^6.9.1",
+    "prettier": "^2.8.8",
     "start-server-and-test": "^2.0.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4335,6 +4335,11 @@ eslint-config-next@^12.2.5:
     eslint-plugin-react "^7.29.4"
     eslint-plugin-react-hooks "^4.5.0"
 
+eslint-config-prettier@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
+  integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
+
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
@@ -7053,6 +7058,11 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
+
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
## Fixes  #826 

This:
- Installs `prettier` and `eslint-config-prettier` dependency
- Move the formatting rules to a newly created `.prettierrc` file
- Add files and folders prettier should ignore using a created `.prettierignore` file