### PR TITLE
Make input field's hostname case-insensitive

### DIFF
--- a/components/aggregation/mat/Form.js
+++ b/components/aggregation/mat/Form.js
@@ -13,6 +13,8 @@ import { TestNameOptions } from '../../TestNameOptions'
 import { categoryCodes } from '../../utils/categoryCodes'
 import { ConfirmationModal } from './ConfirmationModal'
 
+import {asnRegEx, domainRegEx, inputRegEx} from '../../search/FilterSidebar'
+
 const DAY_GRAIN_THRESHOLD_IN_MONTHS = 12
 const WEEK_GRAIN_THRESHOLD_IN_MONTHS = 36
 
@@ -113,7 +115,7 @@ export const Form = ({ onSubmit, query }) => {
 
   const defaultValues = useMemo(() => Object.assign({}, defaultDefaultValues, query), [query])
 
-  const { handleSubmit, control, getValues, watch, reset, setValue } = useForm({
+  const { handleSubmit, control, getValues, watch, reset, setValue, formState: {errors} } = useForm({
     defaultValues,
     shouldUnregister: true,
   })
@@ -268,8 +270,15 @@ export const Form = ({ onSubmit, query }) => {
             name='probe_asn'
             control={control}
             render={({ field }) => (
-              <Input placeholder='AS1234' label={intl.formatMessage({ id: 'Search.Sidebar.ASN' })} {...field} />
+              <Input placeholder='AS1234' label={intl.formatMessage({ id: 'Search.Sidebar.ASN' })} {...field}
+              error={errors?.probe_asn?.message} />
             )}
+            rules={{
+              pattern: {
+                value: asnRegEx,
+                message: intl.formatMessage({ id: 'Search.Sidebar.ASN.Error' }),
+              }
+            }}
           />
         </Box>
         <Box width={[1, 3 / 12]}>
@@ -382,9 +391,16 @@ export const Form = ({ onSubmit, query }) => {
                   <Input
                     label={intl.formatMessage({ id: 'Search.Sidebar.Domain' })}
                     placeholder='twitter.com'
+                    error={errors?.domain?.message}
                     {...field}
                   />
                 )}
+                rules={{
+                  validate: (value = '') =>
+                    String(value).length === 0 ||
+                    domainRegEx.test(value) ||
+                    intl.formatMessage({ id: 'Search.Sidebar.Domain.Error' }),
+                }}
               />
             </Box>
             <Box width={[1, 1 / 5]}>
@@ -394,10 +410,17 @@ export const Form = ({ onSubmit, query }) => {
                 render={({ field }) => (
                   <Input
                     label={intl.formatMessage({ id: 'Search.Sidebar.Input' })}
+                    error={errors?.input?.message}
                     placeholder='https://fbcdn.net/robots.txt'
                     {...field}
                   />
                 )}
+                rules={{
+                  pattern: {
+                    value: inputRegEx,
+                    message: intl.formatMessage({ id: 'Search.Sidebar.Input.Error' })
+                  }
+                }}
               />
             </Box>
             <Box width={[1, 1 / 5]}>

--- a/components/search/FilterSidebar.js
+++ b/components/search/FilterSidebar.js
@@ -72,9 +72,9 @@ function isValidFilterForTestname(testName = 'XX', arrayWithMapping) {
 // to include the measurements of `${today}` as well.
 const tomorrowUTC = dayjs.utc().add(1, 'day').format('YYYY-MM-DD')
 
-const asnRegEx = /^(AS)?([1-9][0-9]*)$/
-const domainRegEx = /(^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}(:[0-9]{1,5})?$)|(^(([0-9]{1,3})\.){3}([0-9]{1,3}))/
-const inputRegEx =
+export const asnRegEx = /^(AS)?([1-9][0-9]*)$/
+export const domainRegEx = /(^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}(:[0-9]{1,5})?$)|(^(([0-9]{1,3})\.){3}([0-9]{1,3}))/
+export const inputRegEx =
   /(^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,}\.[a-zA-Z0-9()]{2,}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$)|(^(([0-9]{1,3})\.){3}([0-9]{1,3}))/
 
 export const queryToFilterMap = {

--- a/pages/chart/mat.js
+++ b/pages/chart/mat.js
@@ -22,6 +22,13 @@ const MeasurementAggregationToolkit = () => {
       for (const p of Object.keys(data)) {
         if (data[p] !== '') {
           params[p] = data[p]
+          // Try to make input's hostname case-insensitive
+          if (p === 'input') {
+            try{
+              let u = new URL(params['input'])
+              params[p] = u.href
+            }catch{}
+          }
         }
       }
       const href = {

--- a/pages/search.js
+++ b/pages/search.js
@@ -254,6 +254,15 @@ const Search = ({ countries, query: queryProp }) => {
         query[queryParam] = state[key]
       }
     }
+    // Try to make input's hostname case-insensitive
+    // domainRegEx doesn't allow uppercase, inputRegEx doesn't allow uppercase scheme
+    if ('input' in query){
+      try{
+        let u = new URL(query['input'])
+        query['input'] = u.href
+      }catch{}
+    }
+
     return query
   }
 


### PR DESCRIPTION
I also copied validation from search to MAT.

🤔Seems that `new URL()` converts the hostname of special (Special scheme: ftp, file, http, https, ws, wss) urls  to lowercase, should I exploit this behavior?

closes #844