### PR TITLE
Add conditional noindex meta tag for specific categories and remove /as/ and /domain/ disallow rules from robots.txt

### DIFF
--- a/pages/domain/[domain].js
+++ b/pages/domain/[domain].js
@@ -182,11 +182,15 @@ const DomainDashboard = ({
     swrOptions,
   )
 
+  const noIndexCategoryCodes = ['PORN', 'PROV', 'GMB']
+
   return (
     <>
       <Head>
         <title>{title}</title>
-        <meta name="robots" content="noindex" />
+        {noIndexCategoryCodes.includes(categoryCode) && (
+          <meta name="robots" content="noindex" />
+        )}
       </Head>
       <div className="container mt-16">
         <h1 className="mb-0">{domain}</h1>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,4 @@
 User-agent: *
 Disallow: /measurement/
 Disallow: /m/
-Disallow: /domain/
-Disallow: /as/
 Crawl-delay: 600


### PR DESCRIPTION
Closes https://github.com/ooni/explorer/issues/1028