### PR TITLE
Fix zh-Hant locale casing so Traditional Chinese translations load

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@
 const { withSentryConfig } = require('@sentry/nextjs')
 
 const DEFAULT_LOCALE = 'en'
-const SUPPORTED_LANGUAGES = [ 'en', 'zh-hant', 'zh-CN', 'vi', 'tr', 'th', 'sw', 'ru', 'pt-BR', 'my', 'km', 'is', 'fr', 'fa', 'es', 'de', 'ar']
+const SUPPORTED_LANGUAGES = [ 'en', 'zh-Hant', 'zh-CN', 'vi', 'tr', 'th', 'sw', 'ru', 'pt-BR', 'my', 'km', 'is', 'fr', 'fa', 'es', 'de', 'ar']
 
 module.exports = withSentryConfig(
   {


### PR DESCRIPTION
## Problem

Switching the UI language to Traditional Chinese (繁體中文) still renders everything in English.

## Root cause

`next.config.js` declares the locale as `zh-hant` (lowercase):

```js
const SUPPORTED_LANGUAGES = [ 'en', 'zh-hant', 'zh-CN', ... ]
```

but the translation file is `public/static/lang/zh-Hant.json` (BCP-47 casing, capital `H`), and the rest of the code already expects `zh-Hant`:

- `components/withIntl.js` fetches `/static/lang/${locale}.json`, i.e. `/static/lang/zh-hant.json`
- `components/DateRangePicker.js` matches `case 'zh-Hant'`
- `utils/intlDisplayNamesInitClient.js` / `intlDisplayNamesInitServer.js` import `@formatjs/intl-displaynames/locale-data/zh-Hant`

On a case-sensitive filesystem (production / Docker / Linux), the fetch of `/static/lang/zh-hant.json` returns 404, so `withIntl.js` hits its catch branch and falls back to `enMessages`. `zh-CN` is unaffected because its locale id and file name (`zh-CN.json`) already match. As a side effect, `DateRangePicker`'s `case 'zh-Hant'` never matches the lowercase locale either.

## Fix

Align the locale id to the BCP-47 canonical casing `zh-Hant`, matching the translation file and the existing `zh-Hant` references. This is a one-line change; `zh-hant` (lowercase) does not appear anywhere else in the repo.

## Note on URLs

This changes the locale URL prefix from `/zh-hant/...` to `/zh-Hant/...`. The old `/zh-hant/...` paths were already serving English (broken localization), so no working localized URL is lost. Happy to add a redirect from the old prefix if you'd prefer to preserve any indexed lowercase URLs.
