### PR TITLE
Forward ooni_run_link_id from MAT View measurements link

### DIFF
--- a/components/aggregation/mat/CustomTooltip.js
+++ b/components/aggregation/mat/CustomTooltip.js
@@ -69,6 +69,7 @@ export const generateSearchQuery = (data, query) => {
     'probe_asn',
     'input',
     'domain',
+    'ooni_run_link_id',
   ].reduce((q, k) => {
     if (k in data) q[k] = data[k]
     else if (query[k]) q[k] = query[k]


### PR DESCRIPTION
## Problem

On the MAT (Measurement Aggregation Toolkit) chart, each tooltip has a **"View measurements >"** link that carries the active filters over to the `/search` measurements list page. When the aggregation is filtered by `ooni_run_link_id`, that filter was **not** included in the generated link, so the destination `/search` page showed unfiltered results instead of the OONI Run link's measurements.

## Cause

The link query is built by `generateSearchQuery` in `components/aggregation/mat/CustomTooltip.js`, which only forwards a fixed allow-list of keys (`probe_cc`, `test_name`, `category_code`, `probe_asn`, `input`, `domain`). `ooni_run_link_id` was missing from that list, even though:

- the MAT carries it in `query` (the MAT `Form` has an `ooni_run_link_id` field), and
- the `/search` page already accepts it as a supported filter (`pages/search.js`).

## Change

Add `ooni_run_link_id` to the forwarded keys. The existing reduce logic handles it correctly: it's a filter (not a chart axis), so it's pulled from the MAT `query` and only included when set and non-empty. Links without an OONI Run filter are unchanged. No other change is needed since `/search` already parses the param.

## Testing

- Opened a MAT chart with `ooni_run_link_id` set, hovered a data point, and confirmed the link's `href` now contains `ooni_run_link_id=<id>`.
- Confirmed `/search` loads with the OONI Run link filter applied.
- Confirmed that with no `ooni_run_link_id` set, the link is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)